### PR TITLE
Alleviate constant lag spikes

### DIFF
--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -411,6 +411,7 @@ class Renderer {
                     // Don't submit NALs for decoding if we have already decoded a later frame
                     objc_sync_enter(frameQueueLock)
                     if timestamp < frameQueueLastTimestamp {
+                        objc_sync_exit(frameQueueLock)
                         continue
                     }
                     
@@ -422,6 +423,7 @@ class Renderer {
                         alvr_report_compositor_start(timestamp)
                         alvr_report_submit(timestamp, 0)
                         
+                        objc_sync_exit(frameQueueLock)
                         continue
                     }
                     objc_sync_exit(frameQueueLock)

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -399,6 +399,13 @@ class Renderer {
                         break
                     }
                     
+                    // Don't submit NALs for decoding if we have already decoded a later frame
+                    objc_sync_enter(frameQueueLock)
+                    if timestamp < frameQueueLastTimestamp {
+                        continue
+                    }
+                    objc_sync_exit(frameQueueLock)
+                    
                     if let vtDecompressionSession = vtDecompressionSession {
                         VideoHandler.feedVideoIntoDecoder(decompressionSession: vtDecompressionSession, nals: nal, timestamp: timestamp, videoFormat: videoFormat!) { [self] imageBuffer in
                             alvr_report_frame_decoded(timestamp)

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -418,10 +418,10 @@ class Renderer {
                     // If we're receiving NALs timestamped from 400ms ago, stop decoding them
                     // to prevent a cascade of needless decoding lag
                     if lastRequestedTimestamp != 0 && lastRequestedTimestamp &- timestamp > 1000*1000*400 {
-                        // notify ALVR we skipped this one
-                        alvr_report_frame_decoded(timestamp)
-                        alvr_report_compositor_start(timestamp)
-                        alvr_report_submit(timestamp, 0)
+                        // notify ALVR we skipped this one?
+                        //alvr_report_frame_decoded(timestamp)
+                        //alvr_report_compositor_start(timestamp)
+                        //alvr_report_submit(timestamp, 0)
                         
                         objc_sync_exit(frameQueueLock)
                         continue


### PR DESCRIPTION
- Don't submit NALs for decoding if we have already decoded a later frame
- If we're receiving NALs timestamped from 400ms ago, stop decoding them to prevent a cascade of needless decoding lag

not a 100% fix, but might help a bit