### PR TITLE
Actually fix spikes

### DIFF
--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -30,7 +30,7 @@ extension LayerRenderer.Clock.Instant.Duration {
 // Larger makes closer objects zoom in more,
 // smaller makes farther objects zoom in more?
 // Could also be a foveation thing idk
-let panel_depth: Float = 0.0000000001
+let panel_depth: Float = 0.1
 
 // TODO(zhuowei): what's the z supposed to be?
 // x, y, z

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -30,7 +30,7 @@ extension LayerRenderer.Clock.Instant.Duration {
 // Larger makes closer objects zoom in more,
 // smaller makes farther objects zoom in more?
 // Could also be a foveation thing idk
-let panel_depth: Float = 0.1
+let panel_depth: Float = 1e-16
 
 // TODO(zhuowei): what's the z supposed to be?
 // x, y, z

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -430,7 +430,7 @@ class Renderer {
                         continue
                     }
                     
-                    // If we're receiving NALs timestamped from >100ms ago, stop decoding them
+                    // If we're receiving NALs timestamped from >400ms ago, stop decoding them
                     // to prevent a cascade of needless decoding lag
                     let ns_diff_from_last_req_ts = lastRequestedTimestamp > timestamp ? lastRequestedTimestamp &- timestamp : 0
                     // TODO: adjustable framerate

--- a/ALVRClient/VideoHandler.swift
+++ b/ALVRClient/VideoHandler.swift
@@ -21,6 +21,14 @@ struct VideoHandler {
         return (Data(buffer: nalBuffer), nalTimestamp)
     }
     
+    static func abandonAllPendingNals() {
+        while true {
+            guard let (nal, timestamp) = VideoHandler.pollNal() else {
+                break
+            }
+        }
+    }
+    
     static func createVideoDecoder(initialNals: Data, codec: Int) -> (VTDecompressionSession, CMFormatDescription) {
         let nalHeader:[UInt8] = [0x00, 0x00, 0x00, 0x01]
         var videoFormat:CMFormatDescription? = nil

--- a/ALVRClient/VideoHandler.swift
+++ b/ALVRClient/VideoHandler.swift
@@ -22,11 +22,7 @@ struct VideoHandler {
     }
     
     static func abandonAllPendingNals() {
-        while true {
-            guard let (nal, timestamp) = VideoHandler.pollNal() else {
-                break
-            }
-        }
+        while let _ = VideoHandler.pollNal() {}
     }
     
     static func createVideoDecoder(initialNals: Data, codec: Int) -> (VTDecompressionSession, CMFormatDescription) {


### PR DESCRIPTION
I'm pretty sure this is an improvement but I may have been looking at it for too long.

- Fixes vsync timing in the graph, and spikes are gone.
  - Spikes were caused by calling `alvr_report_submit` multiple times for the same timestamp
- Requests IDRs if a frame hasn't been decoded in ~1s, or if the last predicted pose is >400ms ago relative to a received NAL (also abandons all queued NALs before requesting the IDR)
- Predicted poses are now relative to vsync, so timing should be more consistent.
  - Because Apple's prediction gets less consistent the further out you request, I added a constant time offset to the actual anchor requests.