### PR TITLE
Bring our own timewarp

### DIFF
--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -13,7 +13,7 @@ struct ContentStageConfiguration: CompositorLayerConfiguration {
         configuration.depthFormat = .depth32Float
         configuration.colorFormat = .bgra8Unorm_srgb
     
-        let foveationEnabled = capabilities.supportsFoveation && false
+        let foveationEnabled = capabilities.supportsFoveation
         configuration.isFoveationEnabled = foveationEnabled
         
         let options: LayerRenderer.Capabilities.SupportedLayoutsOptions = foveationEnabled ? [.foveationEnabled] : []
@@ -39,6 +39,7 @@ struct MetalRendererApp: App {
                 renderer.startRenderLoop()
             }
         }
+        //.upperLimbVisibility(.hidden) // TODO: make this an option
     }
 }
 #endif

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -102,8 +102,6 @@ class Renderer {
     var framesSinceLastIDR:Int = 0
     var framesSinceLastDecode:Int = 0
     
-    let constantTimeOffsetForJitterReductionHack:Double = 33.0/1000.0
-    
     init(_ layerRenderer: LayerRenderer) {
         self.layerRenderer = layerRenderer
         self.device = layerRenderer.device
@@ -627,7 +625,7 @@ class Renderer {
         if renderingStreaming && framePreviouslyPredictedPose != nil {
             // TODO: maybe find some mutable pointer hax to just copy in the ground truth, instead of asking for a value in the past.
             let time = Double(queuedFrame!.timestamp) / Double(NSEC_PER_SEC)
-            //let deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: time - constantTimeOffsetForJitterReductionHack)
+            //let deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: time)
             let deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: vsyncTime)
             drawable.deviceAnchor = deviceAnchor
             
@@ -876,8 +874,8 @@ class Renderer {
         }
     }
     
-    // TODO: once we have our own timewarp, bump this up.
-    static let maxPrediction = 10 * NSEC_PER_MSEC
+    // TODO: figure out how stable Apple's predictions are into the future
+    static let maxPrediction = 50 * NSEC_PER_MSEC
     static let deviceIdHead = alvr_path_string_to_id("/user/head")
     
     func sendTracking(targetTimestamp: Double) {
@@ -887,7 +885,7 @@ class Renderer {
         
         // Predict as far into the future as Apple will allow us.
         for i in 0...20 {
-            deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: targetTimestampWalkedBack - constantTimeOffsetForJitterReductionHack)
+            deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: targetTimestampWalkedBack)
             if deviceAnchor != nil {
                 break
             }

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -351,7 +351,7 @@ class Renderer {
         func uniforms(forViewIndex viewIndex: Int) -> Uniforms {
             let view = drawable.views[viewIndex]
             
-            let viewMatrix = (framePose.inverse * simdDeviceAnchor * view.transform).inverse
+            let viewMatrix = (framePose.inverse * simdDeviceAnchor).inverse
             let projection = ProjectiveTransform3D(leftTangent: Double(view.tangents[0]),
                                                    rightTangent: Double(view.tangents[1]),
                                                    topTangent: Double(view.tangents[2]),

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -323,7 +323,7 @@ class Renderer {
                                                    farZ: Double(drawable.depthRange.x),
                                                    reverseZ: true)
             
-            return Uniforms(projectionMatrix: .init(projection), modelViewMatrix: viewMatrix * modelMatrix)
+            return Uniforms(projectionMatrix: .init(projection), modelViewMatrix: viewMatrix * modelMatrix, tangents: view.tangents)
         }
         
         self.uniforms[0].uniforms.0 = uniforms(forViewIndex: 0)
@@ -350,15 +350,8 @@ class Renderer {
         
         func uniforms(forViewIndex viewIndex: Int) -> Uniforms {
             let view = drawable.views[viewIndex]
-            var viewTrans = matrix_identity_float4x4
-            viewTrans = view.transform.inverse
-            for _ in 0...2 {
-                // Why??
-                viewTrans *= viewTrans
-            }
-        
             
-            let viewMatrix = (framePose.inverse * simdDeviceAnchor * viewTrans).inverse
+            let viewMatrix = (framePose.inverse * simdDeviceAnchor * view.transform).inverse
             let projection = ProjectiveTransform3D(leftTangent: Double(view.tangents[0]),
                                                    rightTangent: Double(view.tangents[1]),
                                                    topTangent: Double(view.tangents[2]),
@@ -366,7 +359,7 @@ class Renderer {
                                                    nearZ: Double(drawable.depthRange.y),
                                                    farZ: Double(drawable.depthRange.x),
                                                    reverseZ: true)
-            return Uniforms(projectionMatrix: .init(projection), modelViewMatrix: viewMatrix)
+            return Uniforms(projectionMatrix: .init(projection), modelViewMatrix: viewMatrix, tangents: view.tangents)
         }
         
         self.uniforms[0].uniforms.0 = uniforms(forViewIndex: 0)

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -30,7 +30,7 @@ extension LayerRenderer.Clock.Instant.Duration {
 // Larger makes closer objects zoom in more,
 // smaller makes farther objects zoom in more?
 // Could also be a foveation thing idk
-let panel_depth: Float = 0.0000000001
+let panel_depth: Float = 0.1
 
 // TODO(zhuowei): what's the z supposed to be?
 // x, y, z

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -479,8 +479,8 @@ class Renderer {
                                 // From what I've read online, the only way to know if an H264 frame has actually completed is if
                                 // the next frame is starting, so keep this around for now just in case.
                                 if frameQueueLastImageBuffer != nil {
-                                    frameQueue.append(QueuedFrame(imageBuffer: frameQueueLastImageBuffer!, timestamp: frameQueueLastTimestamp))
-                                    //frameQueue.append(QueuedFrame(imageBuffer: imageBuffer, timestamp: timestamp))
+                                    //frameQueue.append(QueuedFrame(imageBuffer: frameQueueLastImageBuffer!, timestamp: frameQueueLastTimestamp))
+                                    frameQueue.append(QueuedFrame(imageBuffer: imageBuffer, timestamp: timestamp))
                                 }
                                 else {
                                     frameQueue.append(QueuedFrame(imageBuffer: imageBuffer, timestamp: timestamp))
@@ -551,10 +551,6 @@ class Renderer {
         
         frame.endUpdate()
         
-        if queuedFrame != nil && lastSubmittedTimestamp != queuedFrame!.timestamp {
-            alvr_report_compositor_start(queuedFrame!.timestamp)
-        }
-        
         let renderingStreaming = streamingActiveForFrame && queuedFrame != nil
         
         if !renderingStreaming {
@@ -567,8 +563,14 @@ class Renderer {
             fatalError("Failed to create command buffer")
         }
         
-        guard let drawable = frame.queryDrawable() else { return }
+        guard let drawable = frame.queryDrawable() else {
+            lastQueuedFrame = queuedFrame
+            return
+        }
         
+        if queuedFrame != nil && lastSubmittedTimestamp != queuedFrame!.timestamp {
+            alvr_report_compositor_start(queuedFrame!.timestamp)
+        }
         
         if !alvrInitialized {
             alvrInitialized = true

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -30,7 +30,7 @@ extension LayerRenderer.Clock.Instant.Duration {
 // Larger makes closer objects zoom in more,
 // smaller makes farther objects zoom in more?
 // Could also be a foveation thing idk
-let panel_depth: Float = 0.1
+let panel_depth: Float = 1e-16
 
 // TODO(zhuowei): what's the z supposed to be?
 // x, y, z

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -430,7 +430,7 @@ class Renderer {
                         continue
                     }
                     
-                    // If we're receiving NALs timestamped from >100ms ago, stop decoding them
+                    // If we're receiving NALs timestamped from >400ms ago, stop decoding them
                     // to prevent a cascade of needless decoding lag
                     let ns_diff_from_last_req_ts = lastRequestedTimestamp > timestamp ? lastRequestedTimestamp &- timestamp : 0
                     // TODO: adjustable framerate

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -332,19 +332,8 @@ class Renderer {
         rotation += 0.01
     }
     
-    // A/B helpers, TODO remove
-    var testIter:Int = 0
-    var testIter2:Int = 0
-    
     private func updateGameStateForVideoFrame(drawable: LayerRenderer.Drawable, framePose: simd_float4x4) {
         let simdDeviceAnchor = drawable.deviceAnchor != nil ? drawable.deviceAnchor!.originFromAnchorTransform : matrix_identity_float4x4
-        
-        // A/B helpers, TODO remove
-        testIter2 += 1
-        if testIter2 % 90 == 0 {
-            testIter = (testIter + 1) % 3
-        }
-        
         
         func uniforms(forViewIndex viewIndex: Int) -> Uniforms {
             let view = drawable.views[viewIndex]

--- a/ALVRClient/ShaderTypes.h
+++ b/ALVRClient/ShaderTypes.h
@@ -40,6 +40,7 @@ typedef struct
 {
     matrix_float4x4 projectionMatrix;
     matrix_float4x4 modelViewMatrix;
+    simd_float4 tangents;
 } Uniforms;
 
 typedef struct

--- a/ALVRClient/Shaders.metal
+++ b/ALVRClient/Shaders.metal
@@ -130,6 +130,18 @@ vertex ColorInOut videoFrameVertexShader(Vertex in [[stage_in]],
     Uniforms uniforms = uniformsArray.uniforms[amp_id];
     
     float4 position = float4(in.position, 1.0);
+    if (position.x < 1.0) {
+        position.x = -uniforms.tangents[0]/2.0 - 0.5;
+    }
+    else {
+        position.x = uniforms.tangents[1]/2.0 + 0.5;
+    }
+    if (position.y < 1.0) {
+        position.y = -uniforms.tangents[2]/2.0 - 0.5;
+    }
+    else {
+        position.y = uniforms.tangents[3]/2.0 + 0.5;
+    }
     out.position = uniforms.projectionMatrix * uniforms.modelViewMatrix * position;
     if (amp_id == 0) {
         out.texCoord = in.texCoord;

--- a/ALVRClient/Shaders.metal
+++ b/ALVRClient/Shaders.metal
@@ -131,16 +131,16 @@ vertex ColorInOut videoFrameVertexShader(Vertex in [[stage_in]],
     
     float4 position = float4(in.position, 1.0);
     if (position.x < 1.0) {
-        position.x = -uniforms.tangents[0]/2.0 - 0.5;
+        position.x = -uniforms.tangents[0];
     }
     else {
-        position.x = uniforms.tangents[1]/2.0 + 0.5;
+        position.x = uniforms.tangents[1];
     }
     if (position.y < 1.0) {
-        position.y = -uniforms.tangents[2]/2.0 - 0.5;
+        position.y = -uniforms.tangents[3];
     }
     else {
-        position.y = uniforms.tangents[3]/2.0 + 0.5;
+        position.y = uniforms.tangents[2];
     }
     out.position = uniforms.projectionMatrix * uniforms.modelViewMatrix * position;
     if (amp_id == 0) {

--- a/ALVRClient/Shaders.metal
+++ b/ALVRClient/Shaders.metal
@@ -131,16 +131,16 @@ vertex ColorInOut videoFrameVertexShader(Vertex in [[stage_in]],
     
     float4 position = float4(in.position, 1.0);
     if (position.x < 1.0) {
-        position.x = -uniforms.tangents[0];
+        position.x *= uniforms.tangents[0];
     }
     else {
-        position.x = uniforms.tangents[1];
+        position.x *= uniforms.tangents[1];
     }
     if (position.y < 1.0) {
-        position.y = -uniforms.tangents[3];
+        position.y *= uniforms.tangents[3];
     }
     else {
-        position.y = uniforms.tangents[2];
+        position.y *= uniforms.tangents[2];
     }
     out.position = uniforms.projectionMatrix * uniforms.modelViewMatrix * position;
     if (amp_id == 0) {

--- a/ALVRClient/VideoHandler.swift
+++ b/ALVRClient/VideoHandler.swift
@@ -21,6 +21,14 @@ struct VideoHandler {
         return (Data(buffer: nalBuffer), nalTimestamp)
     }
     
+    static func abandonAllPendingNals() {
+        while true {
+            guard let (nal, timestamp) = VideoHandler.pollNal() else {
+                break
+            }
+        }
+    }
+    
     static func createVideoDecoder(initialNals: Data, codec: Int) -> (VTDecompressionSession, CMFormatDescription) {
         let nalHeader:[UInt8] = [0x00, 0x00, 0x00, 0x01]
         var videoFormat:CMFormatDescription? = nil

--- a/ALVRClient/VideoHandler.swift
+++ b/ALVRClient/VideoHandler.swift
@@ -22,11 +22,7 @@ struct VideoHandler {
     }
     
     static func abandonAllPendingNals() {
-        while true {
-            guard let (nal, timestamp) = VideoHandler.pollNal() else {
-                break
-            }
-        }
+        while let _ = VideoHandler.pollNal() {}
     }
     
     static func createVideoDecoder(initialNals: Data, codec: Int) -> (VTDecompressionSession, CMFormatDescription) {


### PR DESCRIPTION
Based on #31 

Previous implementation relied on Apple's timewarping, and due to Annoying Circumstances with their compositor, we could not keep consistent DeviceAnchors between when we predicted a pose and sent it to ALVR, and when we rendered.

New implementation handles timewarp by rendering a quad at 1m in front of each eye, offset by the past matrix4x4 sent to ALVR. Feels *way* smoother, and feels way more correct when oscillating your head forwards and backwards. Only oddity I've noticed is some occasional judder on pitch rotations.