### PR TITLE
QoL grab-bag: Tickbox for hand visibility, keep SteamVR worldspace when visionOS recenters

### DIFF
--- a/ALVRClient.xcodeproj/project.pbxproj
+++ b/ALVRClient.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C5E5903E2B6379EE00328ED6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C5E5903D2B6379EE00328ED6 /* Assets.xcassets */; };
 		D61E6FE02B71CE080076031A /* VideoHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61E6FDF2B71CE080076031A /* VideoHandler.swift */; };
 		D68FA8092B742F6F0052B7FF /* FFR.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68FA8082B742F6F0052B7FF /* FFR.swift */; };
+		E702FBDC2B899B8700EE75D0 /* GlobalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E702FBDB2B899B8300EE75D0 /* GlobalSettings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -59,6 +60,7 @@
 		D68FA8042B73D5DD0052B7FF /* ALVRClient.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ALVRClient.xcconfig; sourceTree = "<group>"; };
 		D68FA8052B73D6260052B7FF /* Override.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Override.xcconfig; sourceTree = "<group>"; };
 		D68FA8082B742F6F0052B7FF /* FFR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFR.swift; sourceTree = "<group>"; };
+		E702FBDB2B899B8300EE75D0 /* GlobalSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSettings.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 				C5E590312B6379ED00328ED6 /* ALVRClientApp.swift */,
 				C5E590492B637C7E00328ED6 /* ALVRClient-Bridging-Header.h */,
 				C5E590332B6379ED00328ED6 /* ContentView.swift */,
+				E702FBDB2B899B8300EE75D0 /* GlobalSettings.swift */,
 				C5E590352B6379ED00328ED6 /* Renderer.swift */,
 				D61E6FDF2B71CE080076031A /* VideoHandler.swift */,
 				8E458AB22B7E05FB0019FC73 /* EventHandler.swift */,
@@ -219,6 +222,7 @@
 				D61E6FE02B71CE080076031A /* VideoHandler.swift in Sources */,
 				8E458AB32B7E05FB0019FC73 /* EventHandler.swift in Sources */,
 				8E1240FF2B7CC02E005B75F2 /* Entry.swift in Sources */,
+				E702FBDC2B899B8700EE75D0 /* GlobalSettings.swift in Sources */,
 				8E1241032B7CC0E1005B75F2 /* EntryControls.swift in Sources */,
 				D68FA8092B742F6F0052B7FF /* FFR.swift in Sources */,
 				C5E590342B6379ED00328ED6 /* ContentView.swift in Sources */,

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -44,7 +44,7 @@ struct MetalRendererApp: App {
                     EventHandler.shared.start()
                 }
         }
-        .defaultSize(width: 350, height: 300)
+        .defaultSize(width: 650, height: 600)
         .windowStyle(.plain)
         .onChange(of: scenePhase) {
             switch scenePhase {

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -30,7 +30,7 @@ struct MetalRendererApp: App {
     @State private var model = ViewModel()
     @Environment(\.scenePhase) private var scenePhase
     @State private var clientImmersionStyle: ImmersionStyle = .full
-    @State private var clientHandVisibility: Visibility = .visible
+    //@State private var clientHandVisibility: Visibility = .visible
 
     var body: some Scene {
         //Entry point, this is the default window chosen in Info.plist from UIApplicationPreferredDefaultSceneSessionRole
@@ -48,8 +48,6 @@ struct MetalRendererApp: App {
         .defaultSize(width: 650, height: 600)
         .windowStyle(.plain)
         .onChange(of: scenePhase) {
-            clientHandVisibility = GlobalSettings.shared.showHandsOverlaid ? .visible : .hidden
-            
             switch scenePhase {
             case .background:
                 if !model.isShowingClient {
@@ -60,7 +58,9 @@ struct MetalRendererApp: App {
                 // Scene inactive, currently no action for this
                 break
             case .active:
-                // Scene active, currently no action for this
+                // Scene active, make sure everything is started if it isn't
+                EventHandler.shared.initializeAlvr()
+                EventHandler.shared.start()
                 break
             @unknown default:
                 break
@@ -74,7 +74,7 @@ struct MetalRendererApp: App {
             }
         }
         .immersionStyle(selection: $clientImmersionStyle, in: .full)
-        .upperLimbVisibility(clientHandVisibility)
+        .upperLimbVisibility(GlobalSettings.shared.showHandsOverlaid ? .visible : .hidden)
     }
     
 }

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -30,6 +30,7 @@ struct MetalRendererApp: App {
     @State private var model = ViewModel()
     @Environment(\.scenePhase) private var scenePhase
     @State private var clientImmersionStyle: ImmersionStyle = .full
+    @State private var clientHandVisibility: Visibility = .visible
 
     var body: some Scene {
         //Entry point, this is the default window chosen in Info.plist from UIApplicationPreferredDefaultSceneSessionRole
@@ -47,6 +48,8 @@ struct MetalRendererApp: App {
         .defaultSize(width: 650, height: 600)
         .windowStyle(.plain)
         .onChange(of: scenePhase) {
+            clientHandVisibility = GlobalSettings.shared.showHandsOverlaid ? .visible : .hidden
+            
             switch scenePhase {
             case .background:
                 if !model.isShowingClient {
@@ -71,7 +74,7 @@ struct MetalRendererApp: App {
             }
         }
         .immersionStyle(selection: $clientImmersionStyle, in: .full)
-        //.upperLimbVisibility(.hidden) // TODO: make this an option
+        .upperLimbVisibility(clientHandVisibility)
     }
     
 }

--- a/ALVRClient/ContentView.swift
+++ b/ALVRClient/ContentView.swift
@@ -1,8 +1,5 @@
 //
 //  ContentView.swift
-//  ALVRClient
-//
-//  Created by Zhuowei Zhang on 1/26/24.
 //
 
 import SwiftUI

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -11,6 +11,7 @@ struct Entry: View {
     @ObservedObject var eventHandler = EventHandler.shared
     @ObservedObject var globalSettings = GlobalSettings.shared
     @State private var dontKeepSteamVRCenter = false
+    @State private var showHandsOverlaid = false
 
     var body: some View {
         VStack {
@@ -21,6 +22,14 @@ struct Entry: View {
             Text("Options:")
                 .font(.system(size: 20, weight: .bold))
             VStack {
+                Toggle(isOn: $showHandsOverlaid) {
+                    Text("Show hands overlaid")
+                }
+                .toggleStyle(.switch)
+                .onChange(of: showHandsOverlaid) {
+                    globalSettings.showHandsOverlaid = showHandsOverlaid
+                }
+                
                 Toggle(isOn: $dontKeepSteamVRCenter) {
                     Text("Crown Button long-press also recenters SteamVR")
                 }

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -9,11 +9,31 @@ import SwiftUI
 struct Entry: View {
     @Environment(ViewModel.self) private var model
     @ObservedObject var eventHandler = EventHandler.shared
+    @ObservedObject var globalSettings = GlobalSettings.shared
+    @State private var dontKeepSteamVRCenter = false
 
     var body: some View {
         VStack {
             Text("ALVR")
                 .font(.system(size: 50, weight: .bold))
+                .padding()
+            
+            Text("Options:")
+                .font(.system(size: 20, weight: .bold))
+            VStack {
+                Toggle(isOn: $dontKeepSteamVRCenter) {
+                    Text("Crown Button long-press also recenters SteamVR")
+                }
+                .toggleStyle(.switch)
+                .onChange(of: dontKeepSteamVRCenter) {
+                    globalSettings.keepSteamVRCenter = !dontKeepSteamVRCenter
+                }
+            }
+            .frame(width: 450)
+            .padding()
+            
+            Text("Connection Information:")
+                .font(.system(size: 20, weight: .bold))
             
             if eventHandler.hostname != "" && eventHandler.IP != "" {
                 let columns = [
@@ -30,7 +50,7 @@ struct Entry: View {
                 .frame(width: 250, alignment: .center)
             }
         }
-        .frame(minWidth: 350, minHeight: 200)
+        .frame(minWidth: 650, minHeight: 500)
         .glassBackgroundEffect()
         
         EntryControls()

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -70,12 +70,14 @@ class EventHandler: ObservableObject {
     }
     
     func stop() {
-        print("Stopping")
-        inputRunning = false
-        renderStarted = false
+        if renderStarted {
+            print("Stopping")
+            inputRunning = false
+            renderStarted = false
+            alvr_destroy()
+            alvrInitialized = false
+        }
         updateConnectionState(.disconnected)
-        alvr_destroy()
-        alvrInitialized = false
     }
 
     func handleAlvrEvents() {

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -6,6 +6,7 @@ import Foundation
 import Metal
 import VideoToolbox
 import Combine
+import AVKit
 
 class EventHandler: ObservableObject {
     static let shared = EventHandler()
@@ -46,6 +47,7 @@ class EventHandler: ObservableObject {
     init() {}
     
     func initializeAlvr() {
+        fixAudioForDirectStereo()
         if !alvrInitialized {
             print("Initialize ALVR")
             alvrInitialized = true
@@ -56,6 +58,7 @@ class EventHandler: ObservableObject {
     }
     
     func start() {
+        fixAudioForDirectStereo()
         if !inputRunning {
             print("Starting event thread")
             inputRunning = true
@@ -76,6 +79,17 @@ class EventHandler: ObservableObject {
             alvrInitialized = false
         }
         updateConnectionState(.disconnected)
+    }
+
+    func fixAudioForDirectStereo() {
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .allowBluetoothA2DP, .allowAirPlay])
+            try audioSession.setPreferredOutputNumberOfChannels(2)
+            try audioSession.setIntendedSpatialExperience(.bypassed)
+        } catch {
+            print("Failed to set the audio session configuration?")
+        }
     }
 
     func handleAlvrEvents() {

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -1,7 +1,5 @@
 //
 //  EventHandler.swift
-//  ALVRClient
-//
 //
 
 import Foundation

--- a/ALVRClient/FFR.swift
+++ b/ALVRClient/FFR.swift
@@ -1,8 +1,5 @@
 //
 //  FFR.swift
-//  ALVRClient
-//
-//  Created by Shadowfacts on 2/7/24.
 //
 
 import Foundation

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -12,4 +12,5 @@ class GlobalSettings: ObservableObject {
     
     // TODO: configuration persistence
     var keepSteamVRCenter = true
+    var showHandsOverlaid = false
 }

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -1,0 +1,15 @@
+//
+//  GlobalSettings.swift
+//  ALVRClient
+//
+//  Created by Max Thomas on 2/23/24.
+//
+
+import Foundation
+
+class GlobalSettings: ObservableObject {
+    static let shared = GlobalSettings()
+    
+    // TODO: configuration persistence
+    var keepSteamVRCenter = true
+}

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -1,8 +1,5 @@
 //
 //  GlobalSettings.swift
-//  ALVRClient
-//
-//  Created by Max Thomas on 2/23/24.
 //
 
 import Foundation

--- a/ALVRClient/Info.plist
+++ b/ALVRClient/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSHandsTrackingUsageDescription</key>
+	<string>ALVR would like to send hand positions and skeletons to SteamVR.</string>
+	<key>NSWorldSensingUsageDescription</key>
+	<string>ALVR would like to scan your surroundings for obstacles and playspace boundaries.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -442,6 +442,12 @@ class Renderer {
             print("missing anchor!!", queuedFrame!.timestamp)
         }
         
+        // Do NOT move this, just in case, because DeviceAnchor is wonkey and every DeviceAnchor mutates each other.
+        if EventHandler.shared.alvrInitialized /*&& (lastSubmittedTimestamp != queuedFrame?.timestamp)*/ {
+            let targetTimestamp = vsyncTime + (Double(min(alvr_get_head_prediction_offset_ns(), WorldTracker.maxPrediction)) / Double(NSEC_PER_SEC))
+            WorldTracker.shared.sendTracking(targetTimestamp: targetTimestamp)
+        }
+        
         let deviceAnchor = WorldTracker.shared.worldTracking.queryDeviceAnchor(atTimestamp: vsyncTime)
         drawable.deviceAnchor = deviceAnchor
         
@@ -470,12 +476,6 @@ class Renderer {
         commandBuffer.commit()
         
         frame.endSubmission()
-        
-        if EventHandler.shared.alvrInitialized /*&& (lastSubmittedTimestamp != queuedFrame?.timestamp)*/ {
-            let targetTimestamp = vsyncTime + (Double(min(alvr_get_head_prediction_offset_ns(), WorldTracker.maxPrediction)) / Double(NSEC_PER_SEC))
-            WorldTracker.shared.sendTracking(targetTimestamp: targetTimestamp)
-        }
-        
         
         EventHandler.shared.lastQueuedFrame = queuedFrame
     }

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -13,8 +13,10 @@ import ObjectiveC
 
 // The 256 byte aligned size of our uniform structure
 let alignedUniformsSize = (MemoryLayout<UniformsArray>.size + 0xFF) & -0x100
+let alignedPlaneUniformSize = (MemoryLayout<PlaneUniform>.size + 0xFF) & -0x100
 
 let maxBuffersInFlight = 3
+let maxPlanesDrawn = 512
 
 enum RendererError: Error {
     case badVertexDescriptor
@@ -47,18 +49,23 @@ class Renderer {
 
     public let device: MTLDevice
     let commandQueue: MTLCommandQueue
-    var dynamicUniformBuffer: MTLBuffer
+    
     var pipelineState: MTLRenderPipelineState
-    var depthState: MTLDepthStencilState
+    var depthStateAlways: MTLDepthStencilState
+    var depthStateGreater: MTLDepthStencilState
     var colorMap: MTLTexture
 
     let inFlightSemaphore = DispatchSemaphore(value: maxBuffersInFlight)
 
+    var dynamicUniformBuffer: MTLBuffer
     var uniformBufferOffset = 0
-
     var uniformBufferIndex = 0
-
     var uniforms: UnsafeMutablePointer<UniformsArray>
+    
+    var dynamicPlaneUniformBuffer: MTLBuffer
+    var planeUniformBufferOffset = 0
+    var planeUniformBufferIndex = 0
+    var planeUniforms: UnsafeMutablePointer<PlaneUniform>
 
     var rotation: Float = 0
 
@@ -69,6 +76,7 @@ class Renderer {
     var metalTextureCache: CVMetalTextureCache!
     let mtlVertexDescriptor: MTLVertexDescriptor
     var videoFramePipelineState: MTLRenderPipelineState!
+    var videoFrameDepthPipelineState: MTLRenderPipelineState!
     var fullscreenQuadBuffer:MTLBuffer!
     var lastIpd:Float = -1
     
@@ -78,13 +86,16 @@ class Renderer {
         self.commandQueue = self.device.makeCommandQueue()!
 
         let uniformBufferSize = alignedUniformsSize * maxBuffersInFlight
-
         self.dynamicUniformBuffer = self.device.makeBuffer(length:uniformBufferSize,
                                                            options:[MTLResourceOptions.storageModeShared])!
-
         self.dynamicUniformBuffer.label = "UniformBuffer"
-
         uniforms = UnsafeMutableRawPointer(dynamicUniformBuffer.contents()).bindMemory(to:UniformsArray.self, capacity:1)
+
+        let planeUniformBufferSize = alignedPlaneUniformSize * maxPlanesDrawn
+        self.dynamicPlaneUniformBuffer = self.device.makeBuffer(length:planeUniformBufferSize,
+                                                           options:[MTLResourceOptions.storageModeShared])!
+        self.dynamicPlaneUniformBuffer.label = "PlaneUniformBuffer"
+        planeUniforms = UnsafeMutableRawPointer(dynamicPlaneUniformBuffer.contents()).bindMemory(to:PlaneUniform.self, capacity:1)
 
         mtlVertexDescriptor = Renderer.buildMetalVertexDescriptor()
 
@@ -96,11 +107,15 @@ class Renderer {
             fatalError("Unable to compile render pipeline state.  Error info: \(error)")
         }
 
-        let depthStateDescriptor = MTLDepthStencilDescriptor()
-        // TODO(zhuowei): hax
-        depthStateDescriptor.depthCompareFunction = MTLCompareFunction.greater
-        depthStateDescriptor.isDepthWriteEnabled = true
-        self.depthState = device.makeDepthStencilState(descriptor:depthStateDescriptor)!
+        let depthStateDescriptorAlways = MTLDepthStencilDescriptor()
+        depthStateDescriptorAlways.depthCompareFunction = MTLCompareFunction.always
+        depthStateDescriptorAlways.isDepthWriteEnabled = true
+        self.depthStateAlways = device.makeDepthStencilState(descriptor:depthStateDescriptorAlways)!
+        
+        let depthStateDescriptorGreater = MTLDepthStencilDescriptor()
+        depthStateDescriptorGreater.depthCompareFunction = MTLCompareFunction.greater
+        depthStateDescriptorGreater.isDepthWriteEnabled = true
+        self.depthStateGreater = device.makeDepthStencilState(descriptor:depthStateDescriptorGreater)!
 
         do {
             mesh = try Renderer.buildMesh(device: device, mtlVertexDescriptor: mtlVertexDescriptor)
@@ -130,6 +145,12 @@ class Renderer {
         Task {
             let foveationVars = FFR.calculateFoveationVars(EventHandler.shared.streamEvent!.STREAMING_STARTED)
             videoFramePipelineState = try! Renderer.buildRenderPipelineForVideoFrameWithDevice(
+                                device: device,
+                                layerRenderer: layerRenderer,
+                                mtlVertexDescriptor: mtlVertexDescriptor,
+                                foveationVars: foveationVars
+            )
+            videoFrameDepthPipelineState = try! Renderer.buildRenderPipelineForVideoFrameDepthWithDevice(
                                 device: device,
                                 layerRenderer: layerRenderer,
                                 mtlVertexDescriptor: mtlVertexDescriptor,
@@ -180,6 +201,34 @@ class Renderer {
 
         let pipelineDescriptor = MTLRenderPipelineDescriptor()
         pipelineDescriptor.label = "RenderPipeline"
+        pipelineDescriptor.vertexFunction = vertexFunction
+        pipelineDescriptor.fragmentFunction = fragmentFunction
+        pipelineDescriptor.vertexDescriptor = mtlVertexDescriptor
+
+        pipelineDescriptor.colorAttachments[0].pixelFormat = layerRenderer.configuration.colorFormat
+        pipelineDescriptor.depthAttachmentPixelFormat = layerRenderer.configuration.depthFormat
+
+        pipelineDescriptor.maxVertexAmplificationCount = layerRenderer.properties.viewCount
+        
+        return try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+    }
+    
+    // Depth-only renderer, for correcting after overlay render just so Apple's compositor isn't annoying about it
+    class func buildRenderPipelineForVideoFrameDepthWithDevice(device: MTLDevice,
+                                                          layerRenderer: LayerRenderer,
+                                                          mtlVertexDescriptor: MTLVertexDescriptor,
+                                                          foveationVars: FoveationVars) throws -> MTLRenderPipelineState {
+        /// Build a render state pipeline object
+
+        let library = device.makeDefaultLibrary()
+
+        let vertexFunction = library?.makeFunction(name: "videoFrameVertexShader")
+         
+        let fragmentConstants = FFR.makeFunctionConstants(foveationVars)
+        let fragmentFunction = try library?.makeFunction(name: "videoFrameDepthFragmentShader", constantValues: fragmentConstants)
+
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.label = "VideoFrameDepthRenderPipeline"
         pipelineDescriptor.vertexFunction = vertexFunction
         pipelineDescriptor.fragmentFunction = fragmentFunction
         pipelineDescriptor.vertexDescriptor = mtlVertexDescriptor
@@ -272,6 +321,14 @@ class Renderer {
 
         uniforms = UnsafeMutableRawPointer(dynamicUniformBuffer.contents() + uniformBufferOffset).bindMemory(to:UniformsArray.self, capacity:1)
     }
+    
+    private func selectNextPlaneUniformBuffer() {
+        /// Update the state of our uniform buffers before rendering
+
+        planeUniformBufferIndex = (planeUniformBufferIndex + 1) % maxPlanesDrawn
+        planeUniformBufferOffset = alignedPlaneUniformSize * planeUniformBufferIndex
+        planeUniforms = UnsafeMutableRawPointer(dynamicPlaneUniformBuffer.contents() + planeUniformBufferOffset).bindMemory(to:PlaneUniform.self, capacity:1)
+    }
 
     private func updateGameStateForVideoFrame(drawable: LayerRenderer.Drawable, framePose: simd_float4x4) {
         let simdDeviceAnchor = drawable.deviceAnchor != nil ? drawable.deviceAnchor!.originFromAnchorTransform : matrix_identity_float4x4
@@ -279,7 +336,8 @@ class Renderer {
         func uniforms(forViewIndex viewIndex: Int) -> Uniforms {
             let view = drawable.views[viewIndex]
             
-            let viewMatrix = (framePose.inverse * simdDeviceAnchor).inverse
+            let viewMatrix = (simdDeviceAnchor * view.transform).inverse
+            let viewMatrixFrame = (framePose.inverse * simdDeviceAnchor).inverse
             let projection = ProjectiveTransform3D(leftTangent: Double(view.tangents[0]),
                                                    rightTangent: Double(view.tangents[1]),
                                                    topTangent: Double(view.tangents[2]),
@@ -287,7 +345,7 @@ class Renderer {
                                                    nearZ: Double(drawable.depthRange.y),
                                                    farZ: Double(drawable.depthRange.x),
                                                    reverseZ: true)
-            return Uniforms(projectionMatrix: .init(projection), modelViewMatrix: viewMatrix, tangents: view.tangents)
+            return Uniforms(projectionMatrix: .init(projection), modelViewMatrixFrame: viewMatrixFrame, modelViewMatrix: viewMatrix, tangents: view.tangents)
         }
         
         self.uniforms[0].uniforms.0 = uniforms(forViewIndex: 0)
@@ -422,15 +480,37 @@ class Renderer {
         EventHandler.shared.lastQueuedFrame = queuedFrame
     }
     
-    func renderStreamingFrame(drawable: LayerRenderer.Drawable, commandBuffer: MTLCommandBuffer, queuedFrame: QueuedFrame?, framePose: simd_float4x4) {
-        self.updateDynamicBufferState()
-        
-        self.updateGameStateForVideoFrame(drawable: drawable, framePose: framePose)
-        
+    func planeToColor(plane: PlaneAnchor) -> simd_float4 {
+        let subtleChange = 0.75 + ((Float(plane.id.hashValue & 0xFF) / Float(0xff)) * 0.25)
+        switch(plane.classification) {
+            case .ceiling: // #62ea80
+                return simd_float4(0.3843137254901961, 0.9176470588235294, 0.5019607843137255, 1.0) * subtleChange
+            case .door: // #1a5ff4
+                return simd_float4(0.10196078431372549, 0.37254901960784315, 0.9568627450980393, 1.0) * subtleChange
+            case .floor: // #bf6505
+                return simd_float4(0.7490196078431373, 0.396078431372549, 0.0196078431372549, 1.0) * subtleChange
+            case .seat: // #ef67af
+                return simd_float4(0.9372549019607843, 0.403921568627451, 0.6862745098039216, 1.0) * subtleChange
+            case .table: // #c937d3
+                return simd_float4(0.788235294117647, 0.21568627450980393, 0.8274509803921568, 1.0) * subtleChange
+            case .wall: // #dced5e
+                return simd_float4(0.8627450980392157, 0.9294117647058824, 0.3686274509803922, 1.0) * subtleChange
+            case .window: // #4aefce
+                return simd_float4(0.2901960784313726, 0.9372549019607843, 0.807843137254902, 1.0) * subtleChange
+            case .unknown: // #0e576b
+                return simd_float4(0.054901960784313725, 0.3411764705882353, 0.4196078431372549, 1.0) * subtleChange
+            case .undetermined: // #749606
+                return simd_float4(0.4549019607843137, 0.5882352941176471, 0.023529411764705882, 1.0) * subtleChange
+            default:
+                return simd_float4(1.0, 0.0, 0.0, 1.0) * subtleChange // red
+        }
+    }
+    
+    func renderStreamingFrameDepth(drawable: LayerRenderer.Drawable, commandBuffer: MTLCommandBuffer, queuedFrame: QueuedFrame?, framePose: simd_float4x4) {
         let renderPassDescriptor = MTLRenderPassDescriptor()
         renderPassDescriptor.colorAttachments[0].texture = drawable.colorTextures[0]
-        renderPassDescriptor.colorAttachments[0].loadAction = .clear
-        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        renderPassDescriptor.colorAttachments[0].loadAction = .load
+        renderPassDescriptor.colorAttachments[0].storeAction = .dontCare
         renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
         renderPassDescriptor.depthAttachment.texture = drawable.depthTextures[0]
         renderPassDescriptor.depthAttachment.loadAction = .clear
@@ -446,19 +526,16 @@ class Renderer {
             fatalError("Failed to create render encoder")
         }
         
-        renderEncoder.label = "Primary Render Encoder"
+        renderEncoder.label = "Rerender depth"
         
-        renderEncoder.pushDebugGroup("Draw Box")
-        
+        renderEncoder.pushDebugGroup("Draw ALVR Frame Depth")
         renderEncoder.setCullMode(.back)
-        
         renderEncoder.setFrontFacing(.counterClockwise)
-        
-        renderEncoder.setRenderPipelineState(videoFramePipelineState)
-        
-        renderEncoder.setDepthStencilState(depthState)
+        renderEncoder.setRenderPipelineState(videoFrameDepthPipelineState)
+        renderEncoder.setDepthStencilState(depthStateGreater)
         
         renderEncoder.setVertexBuffer(dynamicUniformBuffer, offset:uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
+        renderEncoder.setVertexBuffer(dynamicPlaneUniformBuffer, offset:planeUniformBufferOffset, index: BufferIndex.planeUniforms.rawValue) // unused
         
         let viewports = drawable.views.map { $0.textureMap.viewport }
         
@@ -512,6 +589,165 @@ class Renderer {
         renderEncoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
         renderEncoder.popDebugGroup()
         renderEncoder.endEncoding()
+    }
+    
+    func renderOverlay(drawable: LayerRenderer.Drawable, commandBuffer: MTLCommandBuffer, queuedFrame: QueuedFrame?, framePose: simd_float4x4)
+    {
+        // Toss out the depth buffer, keep colors
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        renderPassDescriptor.colorAttachments[0].texture = drawable.colorTextures[0]
+        renderPassDescriptor.colorAttachments[0].loadAction = .load
+        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+        renderPassDescriptor.depthAttachment.texture = drawable.depthTextures[0]
+        renderPassDescriptor.depthAttachment.loadAction = .clear
+        renderPassDescriptor.depthAttachment.storeAction = .dontCare
+        renderPassDescriptor.depthAttachment.clearDepth = 0.0
+        renderPassDescriptor.rasterizationRateMap = drawable.rasterizationRateMaps.first
+        if layerRenderer.configuration.layout == .layered {
+            renderPassDescriptor.renderTargetArrayLength = drawable.views.count
+        }
+        
+        let viewports = drawable.views.map { $0.textureMap.viewport }
+        
+        guard let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else {
+            fatalError("Failed to create render encoder")
+        }
+        renderEncoder.label = "Plane Render Encoder"
+        renderEncoder.pushDebugGroup("Draw planes")
+        renderEncoder.setCullMode(.back)
+        renderEncoder.setFrontFacing(.counterClockwise)
+        renderEncoder.setViewports(viewports)
+        renderEncoder.setVertexBuffer(dynamicUniformBuffer, offset:uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
+        renderEncoder.setVertexBuffer(dynamicPlaneUniformBuffer, offset:planeUniformBufferOffset, index: BufferIndex.planeUniforms.rawValue) // unused
+        
+        if drawable.views.count > 1 {
+            var viewMappings = (0..<drawable.views.count).map {
+                MTLVertexAmplificationViewMapping(viewportArrayIndexOffset: UInt32($0),
+                                                  renderTargetArrayIndexOffset: UInt32($0))
+            }
+            renderEncoder.setVertexAmplificationCount(viewports.count, viewMappings: &viewMappings)
+        }
+        
+        renderEncoder.setRenderPipelineState(pipelineState)
+        renderEncoder.setDepthStencilState(depthStateGreater)
+        
+        WorldTracker.shared.lockPlaneAnchors()
+        for plane in WorldTracker.shared.planeAnchors {
+            let plane = plane.value
+            let faces = plane.geometry.meshFaces
+            renderEncoder.setVertexBuffer(plane.geometry.meshVertices.buffer, offset: 0, index: VertexAttribute.position.rawValue)
+            renderEncoder.setVertexBuffer(plane.geometry.meshVertices.buffer, offset: 0, index: VertexAttribute.texcoord.rawValue)
+            
+            //self.updateGameStateForVideoFrame(drawable: drawable, framePose: framePose, planeTransform: plane.originFromAnchorTransform)
+            selectNextPlaneUniformBuffer()
+            self.planeUniforms[0].planeTransform = plane.originFromAnchorTransform
+            self.planeUniforms[0].planeColor = planeToColor(plane: plane)
+            renderEncoder.setVertexBuffer(dynamicPlaneUniformBuffer, offset:planeUniformBufferOffset, index: BufferIndex.planeUniforms.rawValue)
+            
+            renderEncoder.drawIndexedPrimitives(type: faces.primitive == .triangle ? MTLPrimitiveType.triangle : MTLPrimitiveType.line,
+                                                indexCount: faces.count*3,
+                                                indexType: faces.bytesPerIndex == 2 ? MTLIndexType.uint16 : MTLIndexType.uint32,
+                                                indexBuffer: faces.buffer,
+                                                indexBufferOffset: 0)
+        }
+        WorldTracker.shared.unlockPlaneAnchors()
+        renderEncoder.popDebugGroup()
+        renderEncoder.endEncoding()
+    }
+    
+    func renderStreamingFrame(drawable: LayerRenderer.Drawable, commandBuffer: MTLCommandBuffer, queuedFrame: QueuedFrame?, framePose: simd_float4x4) {
+        self.updateDynamicBufferState()
+        
+        self.updateGameStateForVideoFrame(drawable: drawable, framePose: framePose)
+        
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        renderPassDescriptor.colorAttachments[0].texture = drawable.colorTextures[0]
+        renderPassDescriptor.colorAttachments[0].loadAction = .clear
+        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+        renderPassDescriptor.depthAttachment.texture = drawable.depthTextures[0]
+        renderPassDescriptor.depthAttachment.loadAction = .clear
+        renderPassDescriptor.depthAttachment.storeAction = .store
+        renderPassDescriptor.depthAttachment.clearDepth = 0.0
+        renderPassDescriptor.rasterizationRateMap = drawable.rasterizationRateMaps.first
+        if layerRenderer.configuration.layout == .layered {
+            renderPassDescriptor.renderTargetArrayLength = drawable.views.count
+        }
+        
+        /// Final pass rendering code here
+        guard let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else {
+            fatalError("Failed to create render encoder")
+        }
+        
+        renderEncoder.label = "Primary Render Encoder"
+        
+        renderEncoder.pushDebugGroup("Draw ALVR Frames")
+        
+        renderEncoder.setCullMode(.back)
+        
+        renderEncoder.setFrontFacing(.counterClockwise)
+        
+        renderEncoder.setRenderPipelineState(videoFramePipelineState)
+        
+        renderEncoder.setDepthStencilState(depthStateAlways)
+        
+        renderEncoder.setVertexBuffer(dynamicUniformBuffer, offset:uniformBufferOffset, index: BufferIndex.uniforms.rawValue)
+        renderEncoder.setVertexBuffer(dynamicPlaneUniformBuffer, offset:planeUniformBufferOffset, index: BufferIndex.planeUniforms.rawValue) // unused
+        
+        let viewports = drawable.views.map { $0.textureMap.viewport }
+        
+        renderEncoder.setViewports(viewports)
+        
+        if drawable.views.count > 1 {
+            var viewMappings = (0..<drawable.views.count).map {
+                MTLVertexAmplificationViewMapping(viewportArrayIndexOffset: UInt32($0),
+                                                  renderTargetArrayIndexOffset: UInt32($0))
+            }
+            renderEncoder.setVertexAmplificationCount(viewports.count, viewMappings: &viewMappings)
+        }
+        
+        guard let queuedFrame = queuedFrame else {
+            renderEncoder.endEncoding()
+            return
+        }
+        let pixelBuffer = queuedFrame.imageBuffer
+        // https://cs.android.com/android/platform/superproject/main/+/main:external/webrtc/sdk/objc/components/renderer/metal/RTCMTLNV12Renderer.mm;l=108;drc=a81e9c82fc3fbc984f0f110407d1e44c9c01958a
+        // TODO(zhuowei): yolo
+        //TODO: prevailing wisdom on stackoverflow says that the CVMetalTextureRef has to be held until
+        // rendering is complete, or the MtlTexture will be invalid?
+        
+        for i in 0...1 {
+            var textureOut:CVMetalTexture! = nil
+            var err:OSStatus = 0
+            let width = CVPixelBufferGetWidth(pixelBuffer)
+            let height = CVPixelBufferGetHeight(pixelBuffer)
+            if i == 0 {
+                err = CVMetalTextureCacheCreateTextureFromImage(
+                    nil, metalTextureCache, pixelBuffer, nil, .r8Unorm,
+                    width, height, 0, &textureOut);
+            } else {
+                err = CVMetalTextureCacheCreateTextureFromImage(
+                    nil, metalTextureCache, pixelBuffer, nil, .rg8Unorm,
+                    width/2, height/2, 1, &textureOut);
+            }
+            if err != 0 {
+                fatalError("CVMetalTextureCacheCreateTextureFromImage \(err)")
+            }
+            guard let metalTexture = CVMetalTextureGetTexture(textureOut) else {
+                fatalError("CVMetalTextureCacheCreateTextureFromImage")
+            }
+            renderEncoder.setFragmentTexture(metalTexture, index: i)
+        }
+        
+        renderEncoder.setVertexBuffer(fullscreenQuadBuffer, offset: 0, index: VertexAttribute.position.rawValue)
+        renderEncoder.setVertexBuffer(fullscreenQuadBuffer, offset: (3*4)*4, index: VertexAttribute.texcoord.rawValue)
+        renderEncoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        renderEncoder.popDebugGroup()
+        renderEncoder.endEncoding()
+        
+        //renderOverlay(drawable: drawable, commandBuffer: commandBuffer, queuedFrame: queuedFrame, framePose: framePose)
+        //renderStreamingFrameDepth(drawable: drawable, commandBuffer: commandBuffer, queuedFrame: queuedFrame, framePose: framePose)
     }
     
     func renderLoop() {

--- a/ALVRClient/ShaderTypes.h
+++ b/ALVRClient/ShaderTypes.h
@@ -22,7 +22,8 @@ typedef NS_ENUM(EnumBackingType, BufferIndex)
 {
     BufferIndexMeshPositions = 0,
     BufferIndexMeshGenerics  = 1,
-    BufferIndexUniforms      = 2
+    BufferIndexUniforms      = 2,
+    BufferIndexPlaneUniforms = 3,
 };
 
 typedef NS_ENUM(EnumBackingType, VertexAttribute)
@@ -39,6 +40,7 @@ typedef NS_ENUM(EnumBackingType, TextureIndex)
 typedef struct
 {
     matrix_float4x4 projectionMatrix;
+    matrix_float4x4 modelViewMatrixFrame;
     matrix_float4x4 modelViewMatrix;
     simd_float4 tangents;
 } Uniforms;
@@ -47,6 +49,12 @@ typedef struct
 {
     Uniforms uniforms[2];
 } UniformsArray;
+
+typedef struct
+{
+    matrix_float4x4 planeTransform;
+    simd_float4 planeColor;
+} PlaneUniform;
 
 #endif /* ShaderTypes_h */
 

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -212,7 +212,6 @@ class WorldTracker {
     // TODO: figure out how stable Apple's predictions are into the future
     
     func sendTracking(targetTimestamp: Double) {
-        let targetTimestamp = CACurrentMediaTime() + Double(min(alvr_get_head_prediction_offset_ns(), WorldTracker.maxPrediction)) / Double(NSEC_PER_SEC)
         var targetTimestampWalkedBack = targetTimestamp
         var deviceAnchor:DeviceAnchor? = nil
         

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -1,7 +1,5 @@
 //
 //  WorldTracker.swift
-//  ALVRClient
-//
 //
 
 import Foundation

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -92,7 +92,9 @@ class WorldTracker {
             
             if update.anchor.id == worldOriginAnchor.id {
                 let anchorTransform = update.anchor.originFromAnchorTransform
-                self.worldTrackingSteamVRTransform = anchorTransform
+                if GlobalSettings.shared.keepSteamVRCenter {
+                    self.worldTrackingSteamVRTransform = anchorTransform
+                }
             }
             else {
                 // TODO: how long do these anchors persist...? Could be useful.

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -13,27 +13,109 @@ class WorldTracker {
     
     let arSession: ARKitSession!
     let worldTracking: WorldTrackingProvider!
+    let sceneReconstruction: SceneReconstructionProvider!
+    let planeDetection: PlaneDetectionProvider!
     
     var deviceAnchorsLock = NSObject()
     var deviceAnchorsQueue = [UInt64]()
     var deviceAnchorsDictionary = [UInt64: simd_float4x4]()
     
+    // Playspace and boundaries state
+    var planeAnchors: [UUID: PlaneAnchor] = [:]
+    var worldTrackingAddedAnchor = false
+    var worldTrackingSteamVRTransform: simd_float4x4 = matrix_identity_float4x4
+    var worldOriginAnchor: WorldAnchor = WorldAnchor(originFromAnchorTransform: matrix_identity_float4x4)
+    
     static let maxPrediction = 30 * NSEC_PER_MSEC
     static let deviceIdHead = alvr_path_string_to_id("/user/head")
-
     
-    init(arSession: ARKitSession = ARKitSession(), worldTracking: WorldTrackingProvider = WorldTrackingProvider()) {
+    init(arSession: ARKitSession = ARKitSession(), worldTracking: WorldTrackingProvider = WorldTrackingProvider(), sceneReconstruction: SceneReconstructionProvider = SceneReconstructionProvider(), planeDetection: PlaneDetectionProvider = PlaneDetectionProvider(alignments: [.horizontal, .vertical])) {
         self.arSession = arSession
         self.worldTracking = worldTracking
+        self.sceneReconstruction = sceneReconstruction
+        self.planeDetection = planeDetection
+        
+        Task {
+            await processReconstructionUpdates()
+        }
+        Task {
+            await processPlaneUpdates()
+        }
+        Task {
+            await processWorldTrackingUpdates()
+        }
     }
     
     func initializeAr() async  {
+    
+        // Reset playspace state
+        self.worldTrackingAddedAnchor = false
+        self.worldTrackingSteamVRTransform = matrix_identity_float4x4
+        self.worldOriginAnchor = WorldAnchor(originFromAnchorTransform: matrix_identity_float4x4)
+        
         do {
-            try await arSession.run([worldTracking])
+            try await arSession.run([worldTracking, sceneReconstruction, planeDetection])
         } catch {
             fatalError("Failed to initialize ARSession")
         }
     }
+    
+    func processReconstructionUpdates() async {
+        for await update in sceneReconstruction.anchorUpdates {
+            let meshAnchor = update.anchor
+            //print(meshAnchor.id, meshAnchor.originFromAnchorTransform)
+        }
+    }
+    
+    func processPlaneUpdates() async {
+        for await update in planeDetection.anchorUpdates {
+            print(update.event, update.anchor.classification, update.anchor.id)
+            if update.anchor.classification == .window {
+                // Skip planes that are windows.
+                continue
+            }
+            switch update.event {
+            case .added, .updated:
+                updatePlane(update.anchor)
+            case .removed:
+                removePlane(update.anchor)
+            }
+            
+        }
+    }
+    
+    // We have an origin anchor which we use to maintain SteamVR's positions
+    // every time visionOS's centering changes.
+    func processWorldTrackingUpdates() async {
+        for await update in worldTracking.anchorUpdates {
+            print(update.anchor.id, update.anchor.description, update.description, update.event)
+            
+            if update.anchor.id == worldOriginAnchor.id {
+                let anchorTransform = update.anchor.originFromAnchorTransform
+                self.worldTrackingSteamVRTransform = anchorTransform
+            }
+            else {
+                // TODO: how long do these anchors persist...? Could be useful.
+                do {
+                    try await worldTracking.removeAnchor(update.anchor)
+                }
+                catch {
+                    // don't care
+                }
+            }
+        }
+    }
+    
+    func updatePlane(_ anchor: PlaneAnchor) {
+        if planeAnchors[anchor.id] == nil {
+            planeAnchors[anchor.id] = anchor
+        }
+    }
+
+    func removePlane(_ anchor: PlaneAnchor) {
+        planeAnchors.removeValue(forKey: anchor.id)
+    }
+
     
     // TODO: figure out how stable Apple's predictions are into the future
     
@@ -62,6 +144,25 @@ class WorldTracker {
             return
         }
         
+        // This is kinda fiddly: worldTracking doesn't have a way to get a list of existing anchors,
+        // and addAnchor only works while fully immersed mode is fully running.
+        // So we have to sandwich it in here where we know worldTracking is online.
+        //
+        // That aside, if we add an anchor at (0,0,0), we will get reports in processWorldTrackingUpdates()
+        // every time the user recenters.
+        if !self.worldTrackingAddedAnchor {
+            self.worldTrackingAddedAnchor = true
+            
+            Task {
+                do {
+                    try await worldTracking.addAnchor(self.worldOriginAnchor)
+                }
+                catch {
+                    // don't care
+                }
+            }
+        }
+        
         let targetTimestampNS = UInt64(targetTimestampWalkedBack * Double(NSEC_PER_SEC))
         
         deviceAnchorsQueue.append(targetTimestampNS)
@@ -70,8 +171,13 @@ class WorldTracker {
             deviceAnchorsDictionary.removeValue(forKey: val)
         }
         deviceAnchorsDictionary[targetTimestampNS] = deviceAnchor.originFromAnchorTransform
-        let orientation = simd_quaternion(deviceAnchor.originFromAnchorTransform)
-        let position = deviceAnchor.originFromAnchorTransform.columns.3
+        
+        // Don't move SteamVR center/bounds when the headset recenters
+        // TODO: make an option
+        var transform = self.worldTrackingSteamVRTransform.inverse * deviceAnchor.originFromAnchorTransform
+        
+        let orientation = simd_quaternion(transform)
+        let position = transform.columns.3
         var trackingMotion = AlvrDeviceMotion(device_id: WorldTracker.deviceIdHead, orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z), linear_velocity: (0, 0, 0), angular_velocity: (0, 0, 0))
         let targetTimestampReqestedNS = UInt64(targetTimestamp * Double(NSEC_PER_SEC))
         let currentTimeNs = UInt64(CACurrentMediaTime() * Double(NSEC_PER_SEC))


### PR DESCRIPTION
**Summary:**

- Added world tracking/plane tracking perms and hand tracking perms (for future work)
- Added options tickboxes in main window:
  - Added hand visibility tickbox
  - Added recentering behavior tickbox
- Added per-room/per-playspace origin anchoring
  - WorldAnchors send an `.added` event on entry to VR mode, so we can check the distance to them and set them as the origin if they're within 3.5m
  - Playspaces can be recentered by holding the crown button 3 times in quick succession. This also purges all origin anchors within 3.5m.
  - If no existing anchors are found, it functions as it did before: A WorldAnchor is added at (0,0,0), and that anchor becomes the new origin for that room.
- Improved launch reliability when backgrounded.
- ~~Fixed a regression which caused the world to wobble and SteamVR overlay to judder (maybe? I definitely fixed the wobble though.)~~ moved to another PR, it does in fact cause judder in SteamVR tho, but the world sloshing will cause sickness so that's what's important

**Recentering behavior:**
The visionOS immersive space is *tiny*, but we can actually mitigate this slightly: WorldTrackingProvider allows us to add WorldAnchors, which means that if we add an anchor at (0,0,0), we will receive updates about where this anchor is. When the Crown Button is held, it will recenter the visionOS coordinate space, and notify us that the origin anchor has moved.

By applying the inverse transform, we can maintain the SteamVR centering even though visionOS has a new origin, effectively extending the playspace, albeit with some manual intervention. Works great for moving between the couch and standing though.

**Settings:**
Currently they aren't saved anywhere, if it's a simple fix I can add it but otherwise let's just kick the can down the road. Dunno how visionOS app storage works tbh.

**Pictures:**
![new-gui](https://github.com/alvr-org/alvr-visionos/assets/1224096/af54a248-9b16-4d3d-bb76-c6a1d3623293)

Video of anchoring in action: https://youtu.be/DGSGwOfSahU 
