### PR TITLE
Override target folder path; change header path

### DIFF
--- a/build_and_repack.sh
+++ b/build_and_repack.sh
@@ -17,13 +17,10 @@ cargo install cbindgen
 # Add iOS target 
 rustup target add aarch64-apple-ios
 
-cargo build --manifest-path ALVR/Cargo.toml --target=aarch64-apple-ios -p alvr_client_core --profile distribution
+CARGO_TARGET_DIR=ALVR/target cargo build --manifest-path ALVR/Cargo.toml --target=aarch64-apple-ios -p alvr_client_core --profile distribution
+mkdir ALVR/build
 cd ALVR/alvr/client_core
-cbindgen --config cbindgen.toml --crate alvr_client_core --output ../../alvr_client_core.h
+cbindgen --config cbindgen.toml --crate alvr_client_core --output ../../build/alvr_client_core.h
 cd ../../../
 
 sh repack_alvr_client.sh
-
-# Clean up ALVR build
-cargo clean --manifest-path ALVR/Cargo.toml
-rm ALVR/alvr_client_core.h

--- a/repack_alvr_client.sh
+++ b/repack_alvr_client.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 BUILDDIR="ALVR/target/aarch64-apple-ios/distribution"
-HEADERPATH="ALVR/alvr_client_core.h"
+HEADERPATH="ALVR/build/alvr_client_core.h"
 rm -r alvrrepack ALVRClientCore.xcframework || true
 mkdir -p alvrrepack/ios alvrrepack/maccatalyst alvrrepack/xros alvrrepack/xrsimulator alvrrepack/headers
 cp "$BUILDDIR/libalvr_client_core.dylib" alvrrepack/ios


### PR DESCRIPTION
Overriding the target folder path is needed in case there it is changed by the systemwide `config.toml`.
I removed the code to clean up cargo and the header file since it's not needed. The header now is generated in the ALVR/build directory which is already gitignored.