### PR TITLE
Hand tracking controller emulation

### DIFF
--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -11,6 +11,7 @@ class WorldTracker {
     
     let arSession: ARKitSession!
     let worldTracking: WorldTrackingProvider!
+    let handTracking: HandTrackingProvider!
     let sceneReconstruction: SceneReconstructionProvider!
     let planeDetection: PlaneDetectionProvider!
     
@@ -31,10 +32,43 @@ class WorldTracker {
     
     static let maxPrediction = 30 * NSEC_PER_MSEC
     static let deviceIdHead = alvr_path_string_to_id("/user/head")
+    static let deviceIdLeftHand = alvr_path_string_to_id("/user/hand/left")
+    static let deviceIdRightHand = alvr_path_string_to_id("/user/hand/right")
+    static let appleHandToSteamVRIndex = [
+        //eBone_Root
+        "wrist": 1,                         //eBone_Wrist
+        "thumbKnuckle": 2,                  //eBone_Thumb0
+        "thumbIntermediateBase": 3,         //eBone_Thumb1
+        "thumbIntermediateTip": 4,          //eBone_Thumb2
+        "thumbTip": 5,                      //eBone_Thumb3
+        "indexFingerMetacarpal": 6,         //eBone_IndexFinger0
+        "indexFingerKnuckle": 7,            //eBone_IndexFinger1
+        "indexFingerIntermediateBase": 8,   //eBone_IndexFinger2
+        "indexFingerIntermediateTip": 9,    //eBone_IndexFinger3
+        "indexFingerTip": 10,               //eBone_IndexFinger4
+        "middleFingerMetacarpal": 11,       //eBone_MiddleFinger0
+        "middleFingerKnuckle": 12,                //eBone_MiddleFinger1
+        "middleFingerIntermediateBase": 13,       //eBone_MiddleFinger2
+        "middleFingerIntermediateTip": 14,        //eBone_MiddleFinger3
+        "middleFingerTip": 15,                    //eBone_MiddleFinger4
+        "ringFingerMetacarpal": 16,         //eBone_RingFinger0
+        "ringFingerKnuckle": 17,                  //eBone_RingFinger1
+        "ringFingerIntermediateBase": 18,         //eBone_RingFinger2
+        "ringFingerIntermediateTip": 19,          //eBone_RingFinger3
+        "ringFingerTip": 20,                      //eBone_RingFinger4
+        "littleFingerMetacarpal": 21,       //eBone_PinkyFinger0
+        "littleFingerKnuckle": 22,                //eBone_PinkyFinger1
+        "littleFingerIntermediateBase": 23,       //eBone_PinkyFinger2
+        "littleFingerIntermediateTip": 24,        //eBone_PinkyFinger3
+        "littleFingerTip": 25,                    //eBone_PinkyFinger4
+        
+        // 26-30 are aux bones and are done by ALVR
+    ]
     
-    init(arSession: ARKitSession = ARKitSession(), worldTracking: WorldTrackingProvider = WorldTrackingProvider(), sceneReconstruction: SceneReconstructionProvider = SceneReconstructionProvider(), planeDetection: PlaneDetectionProvider = PlaneDetectionProvider(alignments: [.horizontal, .vertical])) {
+    init(arSession: ARKitSession = ARKitSession(), worldTracking: WorldTrackingProvider = WorldTrackingProvider(), handTracking: HandTrackingProvider = HandTrackingProvider(), sceneReconstruction: SceneReconstructionProvider = SceneReconstructionProvider(), planeDetection: PlaneDetectionProvider = PlaneDetectionProvider(alignments: [.horizontal, .vertical])) {
         self.arSession = arSession
         self.worldTracking = worldTracking
+        self.handTracking = handTracking
         self.sceneReconstruction = sceneReconstruction
         self.planeDetection = planeDetection
         
@@ -46,6 +80,9 @@ class WorldTracker {
         }
         Task {
             await processWorldTrackingUpdates()
+        }
+        Task {
+            await processHandTrackingUpdates()
         }
     }
     
@@ -60,7 +97,7 @@ class WorldTracker {
         self.sentPoses = 0
         
         do {
-            try await arSession.run([worldTracking, sceneReconstruction, planeDetection])
+            try await arSession.run([worldTracking, handTracking, sceneReconstruction, planeDetection])
         } catch {
             fatalError("Failed to initialize ARSession")
         }
@@ -181,8 +218,17 @@ class WorldTracker {
             case .removed:
                 break
             }
-            
-            
+        }
+    }
+    
+    func processHandTrackingUpdates() async {
+        for await update in handTracking.anchorUpdates {
+            switch update.event {
+            case .added, .updated:
+                break
+            case .removed:
+                break
+            }
         }
     }
     
@@ -205,7 +251,116 @@ class WorldTracker {
     func unlockPlaneAnchors() {
          objc_sync_exit(planeLock)
     }
+    
+    func appleHandOrientationToSteamVr(_ mat: simd_float4x4) -> simd_float4x4 {
+        var ret = mat
+        //var xBasis = [ret.columns.0[0], ret.columns.1[0], ret.columns.2[0]]
+        //var yBasis = [ret.columns.0[1], ret.columns.1[1], ret.columns.2[1]]
+        //var zBasis = [ret.columns.0[2], ret.columns.1[2], ret.columns.2[2]]
+        
+        /*ret.columns.0[0] = zBasis[0]
+        ret.columns.1[0] = zBasis[1]
+        ret.columns.2[0] = zBasis[2]
+        ret.columns.0[2] = -xBasis[0]
+        ret.columns.1[2] = -xBasis[1]
+        ret.columns.2[2] = -xBasis[2]*/
+        
+        //ret.columns.0 = -ret.columns.0
+        //ret.columns.1[0] = -xBasis[1]
+        //ret.columns.2[0] = -xBasis[2]
+        
+        /*ret.columns.0[0] = xBasis[0]
+        ret.columns.1[0] = xBasis[1]
+        ret.columns.2[0] = xBasis[2]
+        
+        ret.columns.0[1] = yBasis[0]
+        ret.columns.1[1] = yBasis[1]
+        ret.columns.2[1] = yBasis[2]
+        
+        ret.columns.0[2] = -zBasis[0]
+        ret.columns.1[2] = -zBasis[1]
+        ret.columns.2[2] = -zBasis[2]*/
+        
+        // WHY DOESN'T THIS WORK?????
+        //ret.columns.2 = -ret.columns.2
+        
+        for i in 0...3 {
+            if ret.columns.0[i] == -0.0 {
+                ret.columns.0[i] = 0.0
+            }
+            if ret.columns.1[i] == -0.0 {
+                ret.columns.1[i] = 0.0
+            }
+            if ret.columns.2[i] == -0.0 {
+                ret.columns.2[i] = 0.0
+            }
+        }
+        
+        //ret.columns.3[2] *= -1
+        
+        return ret
+    }
 
+    // idk unused atm
+    func appleHandOrientationToSteamVrQuat(_ q: simd_quatf) -> simd_quatf {
+        var ret = q.vector
+        let q_vec = q.vector
+        
+        ret.x = q_vec.x
+        ret.y = q_vec.y
+        ret.z = -q_vec.z
+        ret.w = -q_vec.w
+        
+        return simd_quatf(vector: ret)
+    }
+
+    func handAnchorToAlvrDeviceMotion(_ hand: HandAnchor) -> AlvrDeviceMotion {
+        let device_id = hand.chirality == .left ? WorldTracker.deviceIdLeftHand : WorldTracker.deviceIdRightHand
+        
+        let transform = self.worldTrackingSteamVRTransform.inverse * hand.originFromAnchorTransform
+        let orientation = simd_quaternion(transform)
+        let position = transform.columns.3
+        let pose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
+        return AlvrDeviceMotion(device_id: device_id, pose: pose, linear_velocity: (0, 0, 0), angular_velocity: (0, 0, 0))
+    }
+    
+    func handAnchorToSkeleton(_ hand: HandAnchor) -> [AlvrPose]? {
+        var ret: [AlvrPose] = []
+        
+        guard let skeleton = hand.handSkeleton else {
+            return nil
+        }
+        let rootTransform = self.worldTrackingSteamVRTransform.inverse * hand.originFromAnchorTransform
+        let rootOrientation = simd_quaternion(rootTransform)
+        let rootPosition = rootTransform.columns.3
+        for i in 0...25 {
+            let orientation = rootOrientation
+            let position = rootPosition
+            let pose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
+            ret.append(pose)
+        }
+        
+        
+        // Apple has two additional joints: forearmWrist and forearmArm
+        for joint in skeleton.allJoints {
+            let steamVrIdx = WorldTracker.appleHandToSteamVRIndex[joint.name.description, default:-1]
+            print(steamVrIdx, joint.name.description)
+            if steamVrIdx < 0 || steamVrIdx >= 26 {
+                continue
+            }
+            let transformRaw = self.worldTrackingSteamVRTransform.inverse * hand.originFromAnchorTransform * joint.anchorFromJointTransform
+            let transform = transformRaw
+            let orientation = simd_quaternion(appleHandOrientationToSteamVr(transform)) * simd_quatf(from: simd_float3(1.0, 0.0, 0.0), to: simd_float3(0.0, 0.0, 1.0))
+            let position = transform.columns.3
+            let pose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
+            
+            ret[steamVrIdx] = pose
+            //print(i, skeleton.allJoints[i].name)
+        }
+        //ret[1] = ret[0] // eBone_Root = eBone_Wrist
+        
+        return ret
+    }
     
     // TODO: figure out how stable Apple's predictions are into the future
     
@@ -263,17 +418,55 @@ class WorldTracker {
         deviceAnchorsDictionary[targetTimestampNS] = deviceAnchor.originFromAnchorTransform
 
         // Don't move SteamVR center/bounds when the headset recenters
-        var transform = self.worldTrackingSteamVRTransform.inverse * deviceAnchor.originFromAnchorTransform
+        let transform = self.worldTrackingSteamVRTransform.inverse * deviceAnchor.originFromAnchorTransform
         
         let orientation = simd_quaternion(transform)
         let position = transform.columns.3
-        let pose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
-        var trackingMotion = AlvrDeviceMotion(device_id: WorldTracker.deviceIdHead, pose: pose, linear_velocity: (0, 0, 0), angular_velocity: (0, 0, 0))
-        let targetTimestampReqestedNS = UInt64(targetTimestamp * Double(NSEC_PER_SEC))
-        let currentTimeNs = UInt64(CACurrentMediaTime() * Double(NSEC_PER_SEC))
+        let headPose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
+        let headTrackingMotion = AlvrDeviceMotion(device_id: WorldTracker.deviceIdHead, pose: headPose, linear_velocity: (0, 0, 0), angular_velocity: (0, 0, 0))
+        var trackingMotions = [headTrackingMotion]
+        var skeletonLeft:[AlvrPose]? = nil
+        var skeletonRight:[AlvrPose]? = nil
+        
+        var skeletonLeftPtr:UnsafeMutablePointer<AlvrPose>? = nil
+        var skeletonRightPtr:UnsafeMutablePointer<AlvrPose>? = nil
+        
+        let handPoses = handTracking.latestAnchors
+        if let leftHand = handPoses.leftHand {
+            if leftHand.isTracked {
+                trackingMotions.append(handAnchorToAlvrDeviceMotion(leftHand))
+                skeletonLeft = handAnchorToSkeleton(leftHand)
+            }
+        }
+        if let rightHand = handPoses.rightHand {
+            if rightHand.isTracked {
+                trackingMotions.append(handAnchorToAlvrDeviceMotion(rightHand))
+                skeletonRight = handAnchorToSkeleton(rightHand)
+            }
+        }
+        if let skeletonLeft = skeletonLeft {
+            if skeletonLeft.count == 26 {
+                skeletonLeftPtr = UnsafeMutablePointer<AlvrPose>.allocate(capacity: 26)
+                for i in 0...25 {
+                    skeletonLeftPtr![i] = skeletonLeft[i]
+                }
+            }
+        }
+        if let skeletonRight = skeletonRight {
+            if skeletonRight.count == 26 {
+                skeletonRightPtr = UnsafeMutablePointer<AlvrPose>.allocate(capacity: 26)
+                for i in 0...25 {
+                    skeletonRightPtr![i] = skeletonRight[i]
+                }
+            }
+        }
+        
+        //let targetTimestampReqestedNS = UInt64(targetTimestamp * Double(NSEC_PER_SEC))
+        //let currentTimeNs = UInt64(CACurrentMediaTime() * Double(NSEC_PER_SEC))
         //print("asking for:", targetTimestampNS, "diff:", targetTimestampReqestedNS&-targetTimestampNS, "diff2:", targetTimestampNS&-lastRequestedTimestamp, "diff3:", targetTimestampNS&-currentTimeNs)
+
         EventHandler.shared.lastRequestedTimestamp = targetTimestampNS
-        alvr_send_tracking(targetTimestampNS, &trackingMotion, 1, nil, nil)
+        alvr_send_tracking(targetTimestampNS, trackingMotions, UInt64(trackingMotions.count), [UnsafePointer(skeletonLeftPtr), UnsafePointer(skeletonRightPtr)], nil)
     }
     
     func lookupDeviceAnchorFor(timestamp: UInt64) -> simd_float4x4? {

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -350,7 +350,13 @@ class WorldTracker {
             }
             let transformRaw = self.worldTrackingSteamVRTransform.inverse * hand.originFromAnchorTransform * joint.anchorFromJointTransform
             let transform = transformRaw
-            let orientation = simd_quaternion(appleHandOrientationToSteamVr(transform)) * simd_quatf(from: simd_float3(1.0, 0.0, 0.0), to: simd_float3(0.0, 0.0, 1.0))
+            var orientation = simd_quaternion(appleHandOrientationToSteamVr(transform)) * simd_quatf(from: simd_float3(1.0, 0.0, 0.0), to: simd_float3(0.0, 0.0, 1.0))
+            if hand.chirality == .right {
+                orientation = orientation * simd_quatf(from: simd_float3(0.0, 0.0, 1.0), to: simd_float3(0.0, 0.0, -1.0))
+            }
+            else {
+                orientation = orientation * simd_quatf(from: simd_float3(1.0, 0.0, 0.0), to: simd_float3(-1.0, 0.0, 0.0))
+            }
             let position = transform.columns.3
             let pose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
             

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -361,7 +361,12 @@ class WorldTracker {
                     orientation = orientation * WorldTracker.leftForearmOrientationCorrection
                 }
             }
-            let position = transform.columns.3
+            var position = transform.columns.3
+            // Move wrist/elbow slightly outward so that they appear to be on the surface of the arm,
+            // instead of inside it.
+            if steamVrIdx == 26 || steamVrIdx == 27 {
+                position += transform.columns.1 * (0.025 * (hand.chirality == .right ? 1.0 : -1.0))
+            }
             let pose = AlvrPose(orientation: AlvrQuat(x: orientation.vector.x, y: orientation.vector.y, z: orientation.vector.z, w: orientation.vector.w), position: (position.x, position.y, position.z))
             
             ret[steamVrIdx] = pose


### PR DESCRIPTION
- Controller position is mapped to the palm (as defined by OpenXR, midpoint between the middle metacarpal and proximal, orientation is copied from the 'wrist')
- Apple's forearmArm point is mapped to `/user/body/left_elbow`
- Apple's forearmWrist point is mapped to `/user/body/left_knee` (TODO: should we even bother with this point?)
- Skeletal tracking all works, aside from a bug which one PR in the main ALVR repo which will fix, so that the auxiliary bone positions actually are created/sent