### PR TITLE
Repack Rust library into framework instead of dylib for TestFlight

### DIFF
--- a/ALVRClient/ALVRClient-Bridging-Header.h
+++ b/ALVRClient/ALVRClient-Bridging-Header.h
@@ -1,3 +1,3 @@
 #pragma once
-#import "alvr_client_core.h"
+#import "ALVRClientCore/alvr_client_core.h"
 #import "ShaderTypes.h"

--- a/repack_alvr_client.sh
+++ b/repack_alvr_client.sh
@@ -2,25 +2,28 @@
 set -e
 BUILDDIR="ALVR/target/aarch64-apple-ios/distribution"
 HEADERPATH="ALVR/build/alvr_client_core.h"
+target_framework="ALVRClientCore.framework"
+target_lib="ALVRClientCore.framework/ALVRClientCore"
 rm -r alvrrepack ALVRClientCore.xcframework || true
-mkdir -p alvrrepack/ios alvrrepack/maccatalyst alvrrepack/xros alvrrepack/xrsimulator alvrrepack/headers
-cp "$BUILDDIR/libalvr_client_core.dylib" alvrrepack/ios
-cp "$HEADERPATH" alvrrepack/headers
+for plat in ios maccatalyst xros xrsimulator
+do
+	mkdir -p alvrrepack/$plat/$target_framework/Headers
+	cp tools/framework_template/$plat/Info.plist alvrrepack/$plat/$target_framework
+	cp "$HEADERPATH" alvrrepack/$plat/$target_framework/Headers
+done
+cp "$BUILDDIR/libalvr_client_core.dylib" alvrrepack/ios/$target_lib
 
-install_name_tool -id "@rpath/libalvr_client_core.dylib" alvrrepack/ios/libalvr_client_core.dylib
+install_name_tool -id "@rpath/$target_lib" alvrrepack/ios/$target_lib
 
-xcrun vtool -arch arm64 -set-build-version maccatalyst 17.0 17.0 -replace -output alvrrepack/maccatalyst/libalvr_client_core.dylib alvrrepack/ios/libalvr_client_core.dylib
-xcrun vtool -arch arm64 -set-build-version xros 1.0 1.0 -replace -output alvrrepack/xros/libalvr_client_core.dylib alvrrepack/ios/libalvr_client_core.dylib
-xcrun vtool -arch arm64 -set-build-version xrossim 1.0 1.0 -replace -output alvrrepack/xrsimulator/libalvr_client_core.dylib alvrrepack/ios/libalvr_client_core.dylib
+xcrun vtool -arch arm64 -set-build-version maccatalyst 17.0 17.0 -replace -output alvrrepack/maccatalyst/$target_lib alvrrepack/ios/$target_lib
+xcrun vtool -arch arm64 -set-build-version xros 1.0 1.0 -replace -output alvrrepack/xros/$target_lib alvrrepack/ios/$target_lib
+xcrun vtool -arch arm64 -set-build-version xrossim 1.0 1.0 -replace -output alvrrepack/xrsimulator/$target_lib alvrrepack/ios/$target_lib
+
 
 xcodebuild -create-xcframework \
-	-library alvrrepack/ios/libalvr_client_core.dylib \
-	-headers alvrrepack/headers \
-	-library alvrrepack/maccatalyst/libalvr_client_core.dylib \
-	-headers alvrrepack/headers \
-	-library alvrrepack/xros/libalvr_client_core.dylib \
-	-headers alvrrepack/headers \
-	-library alvrrepack/xrsimulator/libalvr_client_core.dylib \
-	-headers alvrrepack/headers \
+	-framework alvrrepack/ios/$target_framework \
+	-framework alvrrepack/maccatalyst/$target_framework \
+	-framework alvrrepack/xros/$target_framework \
+	-framework alvrrepack/xrsimulator/$target_framework \
 	-output ALVRClientCore.xcframework
 

--- a/tools/framework_template/ios/Info.plist
+++ b/tools/framework_template/ios/Info.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>23C64</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundleIdentifier</key>
+	<string>alvr.ALVRClientCore</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>21E5184g</string>
+	<key>DTPlatformName</key>
+	<string>iphoneos</string>
+	<key>DTPlatformVersion</key>
+	<string>17.4</string>
+	<key>DTSDKBuild</key>
+	<string>21E5184g</string>
+	<key>DTSDKName</key>
+	<string>iphoneos17.4</string>
+	<key>DTXcode</key>
+	<string>1530</string>
+	<key>DTXcodeBuild</key>
+	<string>15E5178i</string>
+	<key>MinimumOSVersion</key>
+	<string>16.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+</dict>
+</plist>

--- a/tools/framework_template/maccatalyst/Info.plist
+++ b/tools/framework_template/maccatalyst/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>23C64</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundleIdentifier</key>
+	<string>alvr.ALVRClientCore</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string></string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>DTPlatformVersion</key>
+	<string>14.4</string>
+	<key>DTSDKBuild</key>
+	<string>23E5180g</string>
+	<key>DTSDKName</key>
+	<string>macosx14.4</string>
+	<key>DTXcode</key>
+	<string>1530</string>
+	<key>DTXcodeBuild</key>
+	<string>15E5178i</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>2</integer>
+	</array>
+</dict>
+</plist>

--- a/tools/framework_template/xros/Info.plist
+++ b/tools/framework_template/xros/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>23C64</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundleIdentifier</key>
+	<string>alvr.ALVRClientCore</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>21N301</string>
+	<key>DTPlatformName</key>
+	<string>xros</string>
+	<key>DTPlatformVersion</key>
+	<string>1.0</string>
+	<key>DTSDKBuild</key>
+	<string>21N301</string>
+	<key>DTSDKName</key>
+	<string>xros1.0</string>
+	<key>DTXcode</key>
+	<string>1530</string>
+	<key>DTXcodeBuild</key>
+	<string>15E5178i</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>7</integer>
+	</array>
+</dict>
+</plist>

--- a/tools/framework_template/xrsimulator/Info.plist
+++ b/tools/framework_template/xrsimulator/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>23C64</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundleIdentifier</key>
+	<string>alvr.ALVRClientCore</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ALVRClientCore</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>21N301</string>
+	<key>DTPlatformName</key>
+	<string>xrsimulator</string>
+	<key>DTPlatformVersion</key>
+	<string>1.0</string>
+	<key>DTSDKBuild</key>
+	<string>21N301</string>
+	<key>DTSDKName</key>
+	<string>xrsimulator1.0</string>
+	<key>DTXcode</key>
+	<string>1530</string>
+	<key>DTXcodeBuild</key>
+	<string>15E5178i</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>7</integer>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #52.

(This just uses hardcoded Info.plist templates: is there a better way? Or should we switch to static libraries instead?)