### PR TITLE
Fix launch/relaunch/close issues

### DIFF
--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -54,17 +54,29 @@ struct MetalRendererApp: App {
             case .background:
                 if !model.isShowingClient {
                     //Lobby closed manually: disconnect ALVR
-                    EventHandler.shared.stop()
+                    //EventHandler.shared.stop()
+                    if EventHandler.shared.alvrInitialized {
+                        alvr_pause()
+                    }
+                }
+                if !EventHandler.shared.streamingActive {
+                    EventHandler.shared.handleHeadsetRemoved()
                 }
             case .inactive:
                 // Scene inactive, currently no action for this
                 break
             case .active:
                 // Scene active, make sure everything is started if it isn't
-                WorldTracker.shared.resetPlayspace()
-                EventHandler.shared.initializeAlvr()
-                EventHandler.shared.start()
-                EventHandler.shared.handleHeadsetRemovedOrReentry()
+                if !model.isShowingClient {
+                    WorldTracker.shared.resetPlayspace()
+                    EventHandler.shared.initializeAlvr()
+                    EventHandler.shared.start()
+                    EventHandler.shared.handleHeadsetRemovedOrReentry()
+                }
+                if EventHandler.shared.alvrInitialized {
+                    alvr_resume()
+                }
+                EventHandler.shared.handleHeadsetEntered()
                 break
             @unknown default:
                 break

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -61,8 +61,10 @@ struct MetalRendererApp: App {
                 break
             case .active:
                 // Scene active, make sure everything is started if it isn't
+                WorldTracker.shared.resetPlayspace()
                 EventHandler.shared.initializeAlvr()
                 EventHandler.shared.start()
+                EventHandler.shared.handleHeadsetRemovedOrReentry()
                 break
             @unknown default:
                 break

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -52,7 +52,8 @@ struct MetalRendererApp: App {
         .onChange(of: scenePhase) {
             switch scenePhase {
             case .background:
-                if !model.isShowingClient {
+                // TODO: revisit if we decide to let app run in background (ie, keep it open + reconnect when headset is donned)
+                /*if !model.isShowingClient {
                     //Lobby closed manually: disconnect ALVR
                     //EventHandler.shared.stop()
                     if EventHandler.shared.alvrInitialized {
@@ -61,13 +62,15 @@ struct MetalRendererApp: App {
                 }
                 if !EventHandler.shared.streamingActive {
                     EventHandler.shared.handleHeadsetRemoved()
-                }
+                }*/
+                break
             case .inactive:
                 // Scene inactive, currently no action for this
                 break
             case .active:
                 // Scene active, make sure everything is started if it isn't
-                if !model.isShowingClient {
+                // TODO: revisit if we decide to let app run in background (ie, keep it open + reconnect when headset is donned)
+                /*if !model.isShowingClient {
                     WorldTracker.shared.resetPlayspace()
                     EventHandler.shared.initializeAlvr()
                     EventHandler.shared.start()
@@ -75,7 +78,7 @@ struct MetalRendererApp: App {
                 }
                 if EventHandler.shared.alvrInitialized {
                     alvr_resume()
-                }
+                }*/
                 EventHandler.shared.handleHeadsetEntered()
                 break
             @unknown default:

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -72,14 +72,31 @@ class EventHandler: ObservableObject {
     }
     
     func stop() {
-        if renderStarted {
+        inputRunning = false
+        if alvrInitialized {
             print("Stopping")
-            inputRunning = false
             renderStarted = false
             alvr_destroy()
             alvrInitialized = false
         }
         updateConnectionState(.disconnected)
+    }
+    
+    func hardReset() {
+        streamingActive = false
+        vtDecompressionSession = nil
+        videoFormat = nil
+        lastRequestedTimestamp = 0
+        lastSubmittedTimestamp = 0
+        framesRendered = 0
+        framesSinceLastIDR = 0
+        framesSinceLastDecode = 0
+        lastIpd = -1
+        updateConnectionState(.disconnected)
+                  
+        stop()
+        initializeAlvr()
+        start()
     }
 
     func fixAudioForDirectStereo() {
@@ -139,16 +156,8 @@ class EventHandler: ObservableObject {
                 lastIpd = -1
             case ALVR_EVENT_STREAMING_STOPPED.rawValue:
                 print("streaming stopped")
-                streamingActive = false
-                EventHandler.shared.updateConnectionState(.disconnected)
-                vtDecompressionSession = nil
-                  videoFormat = nil
-                  lastRequestedTimestamp = 0
-                  lastSubmittedTimestamp = 0
-                  framesRendered = 0
-                  framesSinceLastIDR = 0
-                  framesSinceLastDecode = 0
-                  lastIpd = -1
+                hardReset()
+                return
             case ALVR_EVENT_HAPTICS.rawValue:
                 print("haptics: \(alvrEvent.HAPTICS)")
             case ALVR_EVENT_DECODER_CONFIG.rawValue:

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -34,7 +34,7 @@ class EventHandler: ObservableObject {
     var lastQueuedFrame: QueuedFrame? = nil
     var lastRequestedTimestamp: UInt64 = 0
     var lastSubmittedTimestamp: UInt64 = 0
-
+    var lastIpd: Float = -1
 
     var framesSinceLastIDR:Int = 0
     var framesSinceLastDecode:Int = 0
@@ -136,6 +136,7 @@ class EventHandler: ObservableObject {
                 alvr_request_idr()
                 framesSinceLastIDR = 0
                 framesSinceLastDecode = 0
+                lastIpd = -1
             case ALVR_EVENT_STREAMING_STOPPED.rawValue:
                 print("streaming stopped")
                 streamingActive = false
@@ -147,6 +148,7 @@ class EventHandler: ObservableObject {
                   framesRendered = 0
                   framesSinceLastIDR = 0
                   framesSinceLastDecode = 0
+                  lastIpd = -1
             case ALVR_EVENT_HAPTICS.rawValue:
                 print("haptics: \(alvrEvent.HAPTICS)")
             case ALVR_EVENT_DECODER_CONFIG.rawValue:

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -33,6 +33,7 @@ class EventHandler: ObservableObject {
     var frameQueueLastTimestamp: UInt64 = 0
     var frameQueueLastImageBuffer: CVImageBuffer? = nil
     var lastQueuedFrame: QueuedFrame? = nil
+    var lastQueuedFramePose: simd_float4x4? = nil
     var lastRequestedTimestamp: UInt64 = 0
     var lastSubmittedTimestamp: UInt64 = 0
     var lastIpd: Float = -1

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -92,11 +92,22 @@ class EventHandler: ObservableObject {
         framesSinceLastIDR = 0
         framesSinceLastDecode = 0
         lastIpd = -1
+        lastQueuedFrame = nil
         updateConnectionState(.disconnected)
                   
         stop()
         initializeAlvr()
         start()
+    }
+    
+    func handleHeadsetRemovedOrReentry() {
+        lastIpd = -1
+        framesRendered = 0
+        framesSinceLastIDR = 0
+        framesSinceLastDecode = 0
+        lastRequestedTimestamp = 0
+        lastSubmittedTimestamp = 0
+        lastQueuedFrame = nil
     }
 
     func fixAudioForDirectStereo() {

--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -420,7 +420,7 @@ class EventHandler: ObservableObject {
                 let value = keyValuePair[1].trimmingCharacters(in: .whitespaces)
                 
                 if key == "hostname" {
-                    updateHostname(value)
+                    updateHostname(value + ".alvr") // Hack: runtime needs to fix this D:
                 } else if key == "IP" {
                     updateIP(value)
                 }

--- a/ALVRClient/Info.plist
+++ b/ALVRClient/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationExitsOnSuspend</key>
+	<true/>
 	<key>NSHandsTrackingUsageDescription</key>
 	<string>ALVR would like to send hand positions and skeletons to SteamVR.</string>
 	<key>NSWorldSensingUsageDescription</key>

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -102,8 +102,7 @@ class WorldTracker {
         }
     }
     
-    func initializeAr() async  {
-    
+    func resetPlayspace() {
         // Reset playspace state
         self.worldTrackingAddedOriginAnchor = false
         self.worldTrackingSteamVRTransform = matrix_identity_float4x4
@@ -111,6 +110,10 @@ class WorldTracker {
         self.lastUpdatedTs = 0
         self.crownPressCount = 0
         self.sentPoses = 0
+    }
+    
+    func initializeAr() async  {
+        resetPlayspace()
         
         do {
             try await arSession.run([worldTracking, handTracking, sceneReconstruction, planeDetection])
@@ -175,6 +178,7 @@ class WorldTracker {
                         }
                     
                         worldOriginAnchor = update.anchor
+                        self.worldTrackingAddedOriginAnchor = true
                     }
                 }
                 
@@ -215,6 +219,7 @@ class WorldTracker {
                             }
                     
                             self.worldOriginAnchor = WorldAnchor(originFromAnchorTransform: matrix_identity_float4x4)
+                            self.worldTrackingAddedOriginAnchor = true
                             if GlobalSettings.shared.keepSteamVRCenter {
                                 self.worldTrackingSteamVRTransform = anchorTransform
                             }

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -103,6 +103,7 @@ class WorldTracker {
     }
     
     func resetPlayspace() {
+        print("Reset playspace")
         // Reset playspace state
         self.worldTrackingAddedOriginAnchor = false
         self.worldTrackingSteamVRTransform = matrix_identity_float4x4
@@ -188,8 +189,8 @@ class WorldTracker {
                     // This seems to happen when headset is removed, or on app close.
                     if !update.anchor.isTracked {
                         print("Headset removed?")
-                        EventHandler.shared.handleHeadsetRemoved()
-                        resetPlayspace()
+                        //EventHandler.shared.handleHeadsetRemoved()
+                        //resetPlayspace()
                         continue
                     }
 
@@ -414,6 +415,7 @@ class WorldTracker {
             // Prevent audio crackling issues
             if sentPoses > 30 {
                 EventHandler.shared.handleHeadsetRemoved()
+                resetPlayspace()
             }
             return
         }

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -184,6 +184,14 @@ class WorldTracker {
                 
                 if update.anchor.id == worldOriginAnchor.id {
                     self.worldOriginAnchor = update.anchor
+                    
+                    // This seems to happen when headset is removed, or on app close.
+                    if !update.anchor.isTracked {
+                        print("Headset removed?")
+                        EventHandler.shared.handleHeadsetRemoved()
+                        resetPlayspace()
+                        continue
+                    }
 
                     let anchorTransform = update.anchor.originFromAnchorTransform
                     if GlobalSettings.shared.keepSteamVRCenter {
@@ -403,6 +411,10 @@ class WorldTracker {
 
         // Well, I'm out of ideas.
         guard let deviceAnchor = deviceAnchor else {
+            // Prevent audio crackling issues
+            if sentPoses > 30 {
+                EventHandler.shared.handleHeadsetRemoved()
+            }
             return
         }
         


### PR DESCRIPTION
- Fixed the view headlocking when SteamVR is restarted or streamer disconnects
- Fixed view config being "cross-eyed" when restarting SteamVR
- Added a delay for showing frames to prevent any incorrect views being shown (on first entry)
- Fixed indefinite "Connecting..." issue where ALVR would get stuck uninitialized because the Event Thread received a Stop Streaming request immediately after the thread started
- Fixed timewarp bug where frame lowers itself after a time. When timewarping for too long, it now blacks the screen
  - TODO: we should have a cool spinny logo in all screen blackout cases
- Fixed like 95% of the audio cracking on app exit
- exit() the app when the layer is invalidated, if we can
- Added a watchdog for the event thread to ensure that the thread is always alive, exit()s if not
- Added a watchdog for if frames are not being sent to the event thread, to kill the runtime and restart it