### PR TITLE
Joy-Con as controller inputs

### DIFF
--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -340,7 +340,26 @@ class EventHandler: ObservableObject {
                     timeLastFrameSent = CACurrentMediaTime()
                 }
             case ALVR_EVENT_HAPTICS.rawValue:
-                print("haptics: \(alvrEvent.HAPTICS)")
+                //print("haptics: \(alvrEvent.HAPTICS)")
+                let haptics = alvrEvent.HAPTICS
+                var duration = Double(haptics.duration_s)
+                
+                // Hack: Controllers can't do 10ms vibrations.
+                if duration < 0.032 {
+                    duration = 0.032
+                }
+                if haptics.device_id == WorldTracker.deviceIdLeftHand {
+                    WorldTracker.shared.leftHapticsStart = CACurrentMediaTime()
+                    WorldTracker.shared.leftHapticsEnd = CACurrentMediaTime() + duration
+                    WorldTracker.shared.leftHapticsFreq = haptics.frequency
+                    WorldTracker.shared.leftHapticsAmplitude = haptics.amplitude
+                }
+                else {
+                    WorldTracker.shared.rightHapticsStart = CACurrentMediaTime()
+                    WorldTracker.shared.rightHapticsEnd = CACurrentMediaTime() + duration
+                    WorldTracker.shared.rightHapticsFreq = haptics.frequency
+                    WorldTracker.shared.rightHapticsAmplitude = haptics.amplitude
+                }
             case ALVR_EVENT_DECODER_CONFIG.rawValue:
                 streamingActive = true
                 print("create decoder \(alvrEvent.DECODER_CONFIG)")

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -10,6 +10,7 @@ import Spatial
 import ARKit
 import VideoToolbox
 import ObjectiveC
+import GameController
 
 // The 256 byte aligned size of our uniform structure
 let alignedUniformsSize = (MemoryLayout<UniformsArray>.size + 0xFF) & -0x100
@@ -855,7 +856,40 @@ class Renderer {
     }
     
     func renderLoop() {
+    
         layerRenderer.waitUntilRunning()
+        layerRenderer.onSpatialEvent = { eventCollection in
+            for event in eventCollection {
+                if event.kind == .indirectPinch {
+                    print(event)
+                    //print (event.selectionRay?.origin, event.selectionRay?.direction)
+                    if event.selectionRay != nil {
+                    
+                        // Eye gaze
+                        WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.selectionRay!.origin.x + event.selectionRay!.direction.x), Float(event.selectionRay!.origin.y + event.selectionRay!.direction.y), Float(event.selectionRay!.origin.z + event.selectionRay!.direction.z))
+                        
+                        // Eye pose
+                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.selectionRay!.origin.x), Float(event.selectionRay!.origin.y), Float(event.selectionRay!.origin.z))
+                        
+                        // idk
+                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.location3D.x), Float(event.location3D.y), Float(event.location3D.z))
+                        
+                        // idk
+                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.inputDevicePose!.pose3D.position.x + event.inputDevicePose!.pose3D.rotation.axis.x), Float(event.inputDevicePose!.pose3D.position.y + event.inputDevicePose!.pose3D.rotation.axis.y), Float(event.inputDevicePose!.pose3D.position.z + event.inputDevicePose!.pose3D.rotation.axis.z))
+                        
+                        // Pinch connection location
+                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.inputDevicePose!.pose3D.position.x), Float(event.inputDevicePose!.pose3D.position.y), Float(event.inputDevicePose!.pose3D.position.z))
+                        
+                        // Pinch rotation?
+                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.inputDevicePose!.pose3D.rotation.axis.x), Float(event.inputDevicePose!.pose3D.rotation.axis.y), Float(event.inputDevicePose!.pose3D.rotation.axis.z))
+                    }
+                }
+                else {
+                    print("event!", event)
+                }
+            }
+        }
+            
         EventHandler.shared.handleHeadsetRemovedOrReentry()
         var timeSinceLastLoop = CACurrentMediaTime()
         while EventHandler.shared.renderStarted {

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -858,38 +858,7 @@ class Renderer {
     func renderLoop() {
     
         layerRenderer.waitUntilRunning()
-        layerRenderer.onSpatialEvent = { eventCollection in
-            for event in eventCollection {
-                if event.kind == .indirectPinch {
-                    print(event)
-                    //print (event.selectionRay?.origin, event.selectionRay?.direction)
-                    if event.selectionRay != nil {
-                    
-                        // Eye gaze
-                        WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.selectionRay!.origin.x + event.selectionRay!.direction.x), Float(event.selectionRay!.origin.y + event.selectionRay!.direction.y), Float(event.selectionRay!.origin.z + event.selectionRay!.direction.z))
-                        
-                        // Eye pose
-                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.selectionRay!.origin.x), Float(event.selectionRay!.origin.y), Float(event.selectionRay!.origin.z))
-                        
-                        // idk
-                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.location3D.x), Float(event.location3D.y), Float(event.location3D.z))
-                        
-                        // idk
-                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.inputDevicePose!.pose3D.position.x + event.inputDevicePose!.pose3D.rotation.axis.x), Float(event.inputDevicePose!.pose3D.position.y + event.inputDevicePose!.pose3D.rotation.axis.y), Float(event.inputDevicePose!.pose3D.position.z + event.inputDevicePose!.pose3D.rotation.axis.z))
-                        
-                        // Pinch connection location
-                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.inputDevicePose!.pose3D.position.x), Float(event.inputDevicePose!.pose3D.position.y), Float(event.inputDevicePose!.pose3D.position.z))
-                        
-                        // Pinch rotation?
-                        //WorldTracker.shared.hackTestEyeTrackingPos = simd_float3(Float(event.inputDevicePose!.pose3D.rotation.axis.x), Float(event.inputDevicePose!.pose3D.rotation.axis.y), Float(event.inputDevicePose!.pose3D.rotation.axis.z))
-                    }
-                }
-                else {
-                    print("event!", event)
-                }
-            }
-        }
-            
+        
         EventHandler.shared.handleHeadsetRemovedOrReentry()
         var timeSinceLastLoop = CACurrentMediaTime()
         while EventHandler.shared.renderStarted {

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -10,7 +10,6 @@ import Spatial
 import ARKit
 import VideoToolbox
 import ObjectiveC
-import GameController
 
 // The 256 byte aligned size of our uniform structure
 let alignedUniformsSize = (MemoryLayout<UniformsArray>.size + 0xFF) & -0x100

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -480,7 +480,9 @@ class WorldTracker {
                     alvr_send_button(WorldTracker.rightButtonB, boolVal(pressed))
                 }
                 gp.buttonX.pressedChangedHandler = { (button, value, pressed) in
-                    alvr_send_button(WorldTracker.rightButtonX, boolVal(pressed))
+                    alvr_send_button(WorldTracker.rightSqueezeClick, boolVal(pressed))
+                    alvr_send_button(WorldTracker.rightSqueezeValue, scalarVal(value))
+                    alvr_send_button(WorldTracker.rightSqueezeForce, scalarVal(value))
                 }
                 gp.buttonY.pressedChangedHandler = { (button, value, pressed) in
                     alvr_send_button(WorldTracker.rightButtonY, boolVal(pressed))
@@ -494,7 +496,9 @@ class WorldTracker {
                     alvr_send_button(WorldTracker.leftButtonX, boolVal(pressed))
                 }
                 gp.dpad.up.pressedChangedHandler = { (button, value, pressed) in
-                    alvr_send_button(WorldTracker.leftButtonY, boolVal(pressed))
+                    alvr_send_button(WorldTracker.leftSqueezeClick, boolVal(pressed))
+                    alvr_send_button(WorldTracker.leftSqueezeValue, scalarVal(value))
+                    alvr_send_button(WorldTracker.leftSqueezeForce, scalarVal(value))
                 }
                 gp.dpad.left.pressedChangedHandler = { (button, value, pressed) in
                     alvr_send_button(WorldTracker.leftButtonX, boolVal(pressed))

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -823,15 +823,6 @@ class WorldTracker {
             }
         }
         
-        
-        /*var eyeTransform = matrix_identity_float4x4
-        eyeTransform.columns.3 = [hackTestEyeTrackingPos.x, hackTestEyeTrackingPos.y, hackTestEyeTrackingPos.z, 1.0]
-        eyeTransform = self.worldTrackingSteamVRTransform.inverse * eyeTransform
-        let eyePos = eyeTransform.columns.3
-        
-        trackingMotions.append(AlvrDeviceMotion(device_id: WorldTracker.deviceIdLeftFoot, pose: AlvrPose(orientation: AlvrQuat(x: 0.0, y: 0.0, z: 0.0, w: 1.0), position: (eyePos.x, eyePos.y, eyePos.z)), linear_velocity: (0, 0, 0), angular_velocity: (0, 0, 0)))
-        */
-        
         //let targetTimestampReqestedNS = UInt64(targetTimestamp * Double(NSEC_PER_SEC))
         //let currentTimeNs = UInt64(CACurrentMediaTime() * Double(NSEC_PER_SEC))
         //print("asking for:", targetTimestampNS, "diff:", targetTimestampReqestedNS&-targetTimestampNS, "diff2:", targetTimestampNS&-EventHandler.shared.lastRequestedTimestamp, "diff3:", targetTimestampNS&-currentTimeNs)

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -32,9 +32,6 @@ class WorldTracker {
     var crownPressCount = 0
     var sentPoses = 0
     
-    var hackTestEyeTrackingPos: simd_float3 = [0,0,0]
-    var hackTestEyeTrackingQuat: simd_float4 = [0,0,0,1]
-    
     // Hand tracking
     var lastHandsUpdatedTs: TimeInterval = 0
     var lastSentHandsTs: TimeInterval = 0
@@ -48,7 +45,9 @@ class WorldTracker {
     static let deviceIdLeftElbow = alvr_path_string_to_id("/user/body/left_elbow")
     static let deviceIdRightElbow = alvr_path_string_to_id("/user/body/right_elbow")
     static let deviceIdLeftFoot = alvr_path_string_to_id("/user/body/left_foot")
+    static let deviceIdRightFoot = alvr_path_string_to_id("/user/body/right_foot")
     
+    // Left hand inputs
     static let leftButtonA = alvr_path_string_to_id("/user/hand/left/input/a/click")
     static let leftButtonB = alvr_path_string_to_id("/user/hand/left/input/b/click")
     static let leftButtonX = alvr_path_string_to_id("/user/hand/left/input/x/click")
@@ -64,6 +63,7 @@ class WorldTracker {
     static let leftSqueezeValue = alvr_path_string_to_id("/user/hand/left/input/squeeze/value")
     static let leftSqueezeForce = alvr_path_string_to_id("/user/hand/left/input/squeeze/force")
     
+    // Right hand inputs
     static let rightButtonA = alvr_path_string_to_id("/user/hand/right/input/a/click")
     static let rightButtonB = alvr_path_string_to_id("/user/hand/right/input/b/click")
     static let rightButtonX = alvr_path_string_to_id("/user/hand/right/input/x/click")
@@ -548,41 +548,22 @@ class WorldTracker {
                     alvr_send_button(WorldTracker.rightButtonX, boolVal(b["Button X"]?.isPressed ?? false))
                     alvr_send_button(WorldTracker.rightButtonY, boolVal(b["Button Y"]?.isPressed ?? false))
                     alvr_send_button(WorldTracker.rightSystemClick, boolVal(b["Button Options"]?.isPressed ?? false))
-                    //alvr_send_button(WorldTracker.leftButtonY, boolVal(b["Button Y"]?.isPressed ?? false))
                 }
                 else {
-                    /*alvr_send_button(WorldTracker.rightButtonA, boolVal(b["Direction Pad Right"]?.isPressed ?? false))
-                    alvr_send_button(WorldTracker.rightButtonB, boolVal(b["Direction Pad Down"]?.isPressed ?? false))
-                    alvr_send_button(WorldTracker.rightButtonX, boolVal(b["Direction Pad Up"]?.isPressed ?? false))
-                    alvr_send_button(WorldTracker.rightButtonY, boolVal(b["Direction Pad Left"]?.isPressed ?? false))*/
-                    
                     alvr_send_button(WorldTracker.leftButtonA, boolVal(b["Button A"]?.isPressed ?? false))
                     alvr_send_button(WorldTracker.leftButtonB, boolVal(b["Button B"]?.isPressed ?? false))
                     alvr_send_button(WorldTracker.leftButtonX, boolVal(b["Button X"]?.isPressed ?? false))
                     alvr_send_button(WorldTracker.leftButtonY, boolVal(b["Button Y"]?.isPressed ?? false))
                     alvr_send_button(WorldTracker.leftSystemClick, boolVal(b["Button Options"]?.isPressed ?? false))
                     
-                    // Button Menu
                 }
-                
-                /*controller.physicalInputProfile.valueDidChangeHandler = { (gamepad, element) in
-                    //print(controller.extendedGamepad?.leftThumbstick.xAxis)
-                    print(gamepad, element)
-                }*/
             }
             
-            /*controller.extendedGamepad?.valueChangedHandler = { (gamepad, element) in
-                //print(controller.extendedGamepad?.leftThumbstick.xAxis)
-                print(gamepad, element)
-            }*/
-            
-            
+            // TODO motion fusion
             /*controller.motion?.valueChangedHandler = { (motion: GCMotion)->() in
               print(motion.acceleration, motion.rotationRate)
             }
-            controller.motion?.sensorsActive = true
-            //print()
-            print(controller.motion)*/
+            controller.motion?.sensorsActive = true*/
         }
     }
     


### PR DESCRIPTION
I tried to also add soft support for other controllers, but currently ALVR seems to assume the controller inputs are always Quest controllers so I had to do some less-optimal fiddling with the bindings for X/Y/dpad.

Currently, Joy-Con don't support motion, I was planning to make them work via the separated controller profile (hold home+screenshot for 4s), but it's missing a lot of inputs on top of missing motion.

Haptics are supported! Except for frequency, for now.