### PR TITLE
Add support for hand velocities (with patched server)

### DIFF
--- a/ALVRClient/EventHandler.swift
+++ b/ALVRClient/EventHandler.swift
@@ -359,12 +359,12 @@ class EventHandler: ObservableObject {
                     continue
                 }
                 while alvrInitialized {
-                   guard let (nal, timestamp) = VideoHandler.pollNal() else {
+                   guard let (nal, _) = VideoHandler.pollNal() else {
                        fatalError("create decoder: failed to poll nal?!")
                        break
                    }
                    //NSLog("%@", nal as NSData)
-                   let val = (nal[4] & 0x7E) >> 1
+                   //let val = (nal[4] & 0x7E) >> 1
                    if (nal[3] == 0x01 && nal[4] & 0x1f == H264_NAL_TYPE_SPS) || (nal[2] == 0x01 && nal[3] & 0x1f == H264_NAL_TYPE_SPS) {
                        // here we go!
                        (vtDecompressionSession, videoFormat) = VideoHandler.createVideoDecoder(initialNals: nal, codec: H264_NAL_TYPE_SPS)

--- a/ALVRClient/Info.plist
+++ b/ALVRClient/Info.plist
@@ -2,12 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIApplicationExitsOnSuspend</key>
-	<true/>
 	<key>NSHandsTrackingUsageDescription</key>
 	<string>ALVR would like to send hand positions and skeletons to SteamVR.</string>
 	<key>NSWorldSensingUsageDescription</key>
 	<string>ALVR would like to scan your surroundings for obstacles and playspace boundaries.</string>
+	<key>UIApplicationExitsOnSuspend</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -869,7 +869,7 @@ class Renderer {
     func renderLoop() {
         layerRenderer.waitUntilRunning()
         EventHandler.shared.handleHeadsetRemovedOrReentry()
-        var timeSinceLastLoop = CACurrentMediaTime()
+        let timeSinceLastLoop = CACurrentMediaTime()
         while EventHandler.shared.renderStarted {
             if layerRenderer.state == .invalidated {
                 print("Layer is invalidated")

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -132,7 +132,7 @@ class WorldTracker {
     }
     
     func processReconstructionUpdates() async {
-        for await update in sceneReconstruction.anchorUpdates {
+        for await _ in sceneReconstruction.anchorUpdates {
             //let meshAnchor = update.anchor
             //print(meshAnchor.id, meshAnchor.originFromAnchorTransform)
         }
@@ -364,7 +364,7 @@ class WorldTracker {
         let rootOrientation = simd_quatf(ix: rootAlvrPose.orientation.x, iy: rootAlvrPose.orientation.y, iz: rootAlvrPose.orientation.z, r: rootAlvrPose.orientation.w)
         let rootPosition = simd_float3(x: rootAlvrPose.position.0, y: rootAlvrPose.position.1, z: rootAlvrPose.position.2)
         let rootPose = AlvrPose(orientation: AlvrQuat(x: rootOrientation.vector.x, y: rootOrientation.vector.y, z: rootOrientation.vector.z, w: rootOrientation.vector.w), position: (rootPosition.x, rootPosition.y, rootPosition.z))
-        for i in 0...25+2 {
+        for _ in 0...25+2 {
             ret.append(rootPose)
         }
         
@@ -424,7 +424,7 @@ class WorldTracker {
         var deviceAnchor:DeviceAnchor? = nil
         
         // Predict as far into the future as Apple will allow us.
-        for i in 0...20 {
+        for _ in 0...20 {
             deviceAnchor = worldTracking.queryDeviceAnchor(atTimestamp: targetTimestampWalkedBack)
             if deviceAnchor != nil {
                 break
@@ -468,7 +468,7 @@ class WorldTracker {
         }
         sentPoses += 1
         
-        let targetTimestampNS = UInt64(targetTimestampWalkedBack * Double(NSEC_PER_SEC))
+        //let targetTimestampNS = UInt64(targetTimestampWalkedBack * Double(NSEC_PER_SEC))
         let realTargetTimestampNS = UInt64(realTargetTimestamp * Double(NSEC_PER_SEC))
         
         deviceAnchorsQueue.append(realTargetTimestampNS)

--- a/ALVRClient/WorldTracker.swift
+++ b/ALVRClient/WorldTracker.swift
@@ -34,6 +34,8 @@ class WorldTracker {
     // Hand tracking
     var lastHandsUpdatedTs: TimeInterval = 0
     var lastSentHandsTs: TimeInterval = 0
+    var lastLeftHandPose: AlvrPose = AlvrPose()
+    var lastRightHandPose: AlvrPose = AlvrPose()
     
     static let maxPrediction = 30 * NSEC_PER_MSEC
     static let deviceIdHead = alvr_path_string_to_id("/user/head")
@@ -337,9 +339,19 @@ class WorldTracker {
 
     func handAnchorToAlvrDeviceMotion(_ hand: HandAnchor) -> AlvrDeviceMotion {
         let device_id = hand.chirality == .left ? WorldTracker.deviceIdLeftHand : WorldTracker.deviceIdRightHand
+        let lastPose: AlvrPose = hand.chirality == .left ? lastLeftHandPose : lastRightHandPose
+        let pose: AlvrPose = handAnchorToPose(hand)
+        let dp = (pose.position.0 - lastPose.position.0, pose.position.1 - lastPose.position.1, pose.position.2 - lastPose.position.2)
+        let dt = Float(lastHandsUpdatedTs - lastSentHandsTs)
         
-        let pose = handAnchorToPose(hand)
-        return AlvrDeviceMotion(device_id: device_id, pose: pose, linear_velocity: (0, 0, 0), angular_velocity: (0, 0, 0))
+        if hand.chirality == .left {
+            lastLeftHandPose = pose
+        }
+        else {
+            lastRightHandPose = pose
+        }
+        
+        return AlvrDeviceMotion(device_id: device_id, pose: pose, linear_velocity: (dp.0 / dt, dp.1 / dt, dp.2 / dt), angular_velocity: (0, 0, 0))
     }
     
     func handAnchorToSkeleton(_ hand: HandAnchor) -> [AlvrPose]? {


### PR DESCRIPTION
Forwards the velocity of both hands to the server rather than a zero vector. Has no effect unless the alvr-streamer server has been patched to forward hand velocities to SteamVR.