### PR TITLE
Client-side MetalFX upscaling for image quality enhancement.

### DIFF
--- a/ALVRClient.xcodeproj/project.pbxproj
+++ b/ALVRClient.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		693F1CBA2BADFC7200BABE52 /* ImageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693F1CB92BADFC7200BABE52 /* ImageUtils.swift */; };
+		69681A7D2BADDD8F00810B3A /* MetalFXUpscaler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69681A7C2BADDD8F00810B3A /* MetalFXUpscaler.swift */; };
 		8E1240FF2B7CC02E005B75F2 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1240FE2B7CC02E005B75F2 /* Entry.swift */; };
 		8E1241032B7CC0E1005B75F2 /* EntryControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1241022B7CC0E1005B75F2 /* EntryControls.swift */; };
 		8E458AB32B7E05FB0019FC73 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E458AB22B7E05FB0019FC73 /* EventHandler.swift */; };
@@ -41,6 +43,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		693F1CB92BADFC7200BABE52 /* ImageUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUtils.swift; sourceTree = "<group>"; };
+		69681A7C2BADDD8F00810B3A /* MetalFXUpscaler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalFXUpscaler.swift; sourceTree = "<group>"; };
 		8E1240FE2B7CC02E005B75F2 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		8E1241022B7CC0E1005B75F2 /* EntryControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryControls.swift; sourceTree = "<group>"; };
 		8E458AB22B7E05FB0019FC73 /* EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
@@ -130,10 +134,12 @@
 				8E458AB42B7E2C010019FC73 /* WorldTracker.swift */,
 				C5E590372B6379ED00328ED6 /* Shaders.metal */,
 				C5E590392B6379ED00328ED6 /* ShaderTypes.h */,
+				693F1CB92BADFC7200BABE52 /* ImageUtils.swift */,
 				C5E5903D2B6379EE00328ED6 /* Assets.xcassets */,
 				C588CC1F2B6BC7AA00D00DF0 /* ALVRClientCore.xcframework */,
 				C5E5903F2B6379EE00328ED6 /* Info.plist */,
 				C5E5903A2B6379ED00328ED6 /* Preview Content */,
+				69681A7C2BADDD8F00810B3A /* MetalFXUpscaler.swift */,
 			);
 			path = ALVRClient;
 			sourceTree = "<group>";
@@ -239,8 +245,10 @@
 				D68FA8092B742F6F0052B7FF /* FFR.swift in Sources */,
 				9ED257172B8062A2008DC22F /* Settings.swift in Sources */,
 				C5E590362B6379ED00328ED6 /* Renderer.swift in Sources */,
+				69681A7D2BADDD8F00810B3A /* MetalFXUpscaler.swift in Sources */,
 				C5E590322B6379ED00328ED6 /* ALVRClientApp.swift in Sources */,
 				8E739C8B2B78990B0045ED16 /* ViewModel.swift in Sources */,
+				693F1CBA2BADFC7200BABE52 /* ImageUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -99,7 +99,7 @@ struct MetalRendererApp: App {
         // But also, somehow it doesn't work, so I'm out of ideas here.
         ImmersiveSpace(id: "ClientWithHands") {
             CompositorLayer(configuration: ContentStageConfiguration()) { layerRenderer in
-                let renderer = Renderer(layerRenderer)
+                let renderer = Renderer(layerRenderer, global_settings: gStore.settings)
                 renderer.startRenderLoop()
             }
         }
@@ -108,7 +108,7 @@ struct MetalRendererApp: App {
         
         ImmersiveSpace(id: "ClientNoHands") {
             CompositorLayer(configuration: ContentStageConfiguration()) { layerRenderer in
-                let renderer = Renderer(layerRenderer)
+                let renderer = Renderer(layerRenderer, global_settings: gStore.settings)
                 renderer.startRenderLoop()
             }
         }

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -44,10 +44,16 @@ struct Entry: View {
                 
                 if settings.enableMetalFX {
                     Text("MetalFX Upscaling \(String(format: "%.1f", settings.upscalingFactor))")
-                        .font(.system(size: 20, weight: .bold))
                     
                     Slider(value: $settings.upscalingFactor, in: 1.1 ... 2.5, step: 0.1) {
                     }
+                    
+                    Toggle(isOn: $settings.enableDebugSaveScreenshot) {
+                        Text("Save debug screenshot*")
+                        Text("*This will reduce system performance*")
+                        .font(.system(size: 10))
+                    }
+                    .toggleStyle(.switch)
                 }
                 
                 

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -36,6 +36,12 @@ struct Entry: View {
                     .font(.system(size: 10))
                 }
                 .toggleStyle(.switch)
+
+                Text("MetalFX Upscaling \(settings.upscalingFactor)")
+                    .font(.system(size: 20, weight: .bold))
+                
+                Slider(value: $settings.upscalingFactor, in: 1.0 ... 2.5, step: 0.1) {
+                }
                 
                 
             }

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -37,10 +37,17 @@ struct Entry: View {
                 }
                 .toggleStyle(.switch)
 
-                Text("MetalFX Upscaling \(settings.upscalingFactor)")
-                    .font(.system(size: 20, weight: .bold))
+                Toggle(isOn: $settings.enableMetalFX) {
+                    Text("Enable MetalFX for upscaling*")
+                }
+                .toggleStyle(.switch)
                 
-                Slider(value: $settings.upscalingFactor, in: 1.0 ... 2.5, step: 0.1) {
+                if settings.enableMetalFX {
+                    Text("MetalFX Upscaling \(String(format: "%.1f", settings.upscalingFactor))")
+                        .font(.system(size: 20, weight: .bold))
+                    
+                    Slider(value: $settings.upscalingFactor, in: 1.1 ... 2.5, step: 0.1) {
+                    }
                 }
                 
                 

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -10,6 +10,7 @@ struct GlobalSettings: Codable {
     var showHandsOverlaid: Bool = false
     var setDisplayTo96Hz: Bool = false
     var upscalingFactor: Float32 = 1.0
+    var enableMetalFX: Bool = false
     
     init() {}
     
@@ -20,6 +21,7 @@ struct GlobalSettings: Codable {
         self.showHandsOverlaid = try container.decodeIfPresent(Bool.self, forKey: .showHandsOverlaid) ?? self.showHandsOverlaid
         self.setDisplayTo96Hz = try container.decodeIfPresent(Bool.self, forKey: .setDisplayTo96Hz) ?? self.setDisplayTo96Hz
         self.upscalingFactor = try container.decodeIfPresent(Float32.self, forKey: .upscalingFactor) ?? self.upscalingFactor
+        self.enableMetalFX = try container.decodeIfPresent(Bool.self, forKey: .enableMetalFX) ?? self.enableMetalFX
     }
 }
 

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -11,7 +11,8 @@ struct GlobalSettings: Codable {
     var setDisplayTo96Hz: Bool = false
     var upscalingFactor: Float32 = 1.0
     var enableMetalFX: Bool = false
-    
+    var enableDebugSaveScreenshot: Bool = false
+
     init() {}
     
     init(from decoder: Decoder) throws {
@@ -22,6 +23,7 @@ struct GlobalSettings: Codable {
         self.setDisplayTo96Hz = try container.decodeIfPresent(Bool.self, forKey: .setDisplayTo96Hz) ?? self.setDisplayTo96Hz
         self.upscalingFactor = try container.decodeIfPresent(Float32.self, forKey: .upscalingFactor) ?? self.upscalingFactor
         self.enableMetalFX = try container.decodeIfPresent(Bool.self, forKey: .enableMetalFX) ?? self.enableMetalFX
+        self.enableDebugSaveScreenshot = try container.decodeIfPresent(Bool.self, forKey: .enableDebugSaveScreenshot) ?? self.enableDebugSaveScreenshot
     }
 }
 

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -9,6 +9,7 @@ struct GlobalSettings: Codable {
     var keepSteamVRCenter: Bool = true
     var showHandsOverlaid: Bool = false
     var setDisplayTo96Hz: Bool = false
+    var upscalingFactor: Float32 = 1.0
     
     init() {}
     
@@ -18,6 +19,7 @@ struct GlobalSettings: Codable {
         self.keepSteamVRCenter = try container.decodeIfPresent(Bool.self, forKey: .keepSteamVRCenter) ?? self.keepSteamVRCenter
         self.showHandsOverlaid = try container.decodeIfPresent(Bool.self, forKey: .showHandsOverlaid) ?? self.showHandsOverlaid
         self.setDisplayTo96Hz = try container.decodeIfPresent(Bool.self, forKey: .setDisplayTo96Hz) ?? self.setDisplayTo96Hz
+        self.upscalingFactor = try container.decodeIfPresent(Float32.self, forKey: .upscalingFactor) ?? self.upscalingFactor
     }
 }
 

--- a/ALVRClient/ImageUtils.swift
+++ b/ALVRClient/ImageUtils.swift
@@ -203,47 +203,6 @@ func convertRGBA16FloatToRGBA8Unorm(device: MTLDevice, commandQueue: MTLCommandQ
     return destinationTexture
 }
 
-//
-//func convertTexture16Fto8U(device: MTLDevice, commandQueue: MTLCommandQueue, inputTexture: MTLTexture) -> MTLTexture? {
-//    guard let library = device.makeDefaultLibrary(),
-//          let kernelFunction = library.makeFunction(name: "rgba16FloatToRgba8Unorm"),
-//          let computePipelineState = try? device.makeComputePipelineState(function: kernelFunction),
-//          let commandBuffer = commandQueue.makeCommandBuffer(),
-//          let computeEncoder = commandBuffer.makeComputeCommandEncoder() else {
-//        print("Failed to set up Metal components for conversion.")
-//        return nil
-//    }
-//
-//    // Create the output texture with RGBA8Unorm format
-//    let descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba8Unorm,
-//                                                              width: inputTexture.width,
-//                                                              height: inputTexture.height,
-//                                                              mipmapped: false)
-//    descriptor.usage = [.shaderWrite, .shaderRead]
-//    guard let outputTexture = device.makeTexture(descriptor: descriptor) else {
-//        print("Failed to create output texture.")
-//        return nil
-//    }
-//
-//    // Set up and execute the compute shader
-//    computeEncoder.setComputePipelineState(computePipelineState)
-//    computeEncoder.setTexture(inputTexture, index: 0)
-//    computeEncoder.setTexture(outputTexture, index: 1)
-//    
-//    let threadgroupSize = MTLSize(width: 8, height: 8, depth: 1) // Adjust based on GPU
-//    let threadgroups = MTLSize(width: (inputTexture.width + threadgroupSize.width - 1) / threadgroupSize.width,
-//                               height: (inputTexture.height + threadgroupSize.height - 1) / threadgroupSize.height,
-//                               depth: 1)
-//    
-//    computeEncoder.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadgroupSize)
-//    computeEncoder.endEncoding()
-////    commandBuffer.commit()
-////    commandBuffer.waitUntilCompleted()
-//    
-//    return outputTexture
-//}
-
-
 func textureToImage(texture: MTLTexture) -> CGImage? {
     let bytesPerPixel = 4
     let bytesPerRow = bytesPerPixel * texture.width

--- a/ALVRClient/ImageUtils.swift
+++ b/ALVRClient/ImageUtils.swift
@@ -1,8 +1,199 @@
 //
 //  ImageUtils.swift
-//  ALVRClient
 //
-//  Created by 徐浩 on 2024/3/23.
+//  Created by @xuhao1 on 2024/3/17.
 //
 
 import Foundation
+import CoreGraphics
+import ImageIO
+import Metal
+import MetalFX
+import CoreGraphics
+import MobileCoreServices
+
+func saveCGImageToFile(image: CGImage, url: URL, format: CFString = kUTTypePNG) {
+    guard let destination = CGImageDestinationCreateWithURL(url as CFURL, format, 1, nil) else {
+        print("Failed to create CGImageDestination for URL: \(url)")
+        return
+    }
+
+    CGImageDestinationAddImage(destination, image, nil)
+
+    // Finalize the image destination to actually write the data to file
+    if !CGImageDestinationFinalize(destination) {
+        print("Failed to save image to URL: \(url)")
+    } else {
+        print("Image successfully saved to URL: \(url)")
+    }
+}
+
+class YUV2RGBConverter
+{
+    var computePipelineState: MTLComputePipelineState!
+    var device: MTLDevice!
+    var outputTexture: MTLTexture? = nil
+    
+    init?(device: MTLDevice)
+    {
+        // Assuming `device` is your MTLDevice instance and you've set it up already
+        self.device = device
+        let defaultLibrary = device.makeDefaultLibrary()!
+        let kernelFunction = defaultLibrary.makeFunction(name: "yuvToRgbComputeKernel")
+        do {
+            computePipelineState = try device.makeComputePipelineState(function: kernelFunction!)
+        }
+        catch {
+            print("shader failed")
+        }
+    }
+    
+    func addToBuffer(commandBuffer: MTLCommandBuffer, metalY: MTLTexture, metalUV: MTLTexture) -> MTLTexture? {
+        // Prepare the output texture with the same dimensions as the Y texture
+        if (outputTexture == nil)
+        {
+            let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba8Unorm,
+                                                                             width: metalY.width,
+                                                                             height: metalY.height,
+                                                                             mipmapped: false)
+            textureDescriptor.usage = [.shaderWrite, .shaderRead]
+            self.outputTexture = device.makeTexture(descriptor: textureDescriptor)
+            if self.outputTexture == nil {
+                print("Failed to create output texture")
+                return nil
+            }
+        }
+        
+        guard let computeCommandEncoder = commandBuffer.makeComputeCommandEncoder() else {
+          print("Failed to create command encoder")
+          return nil
+        }
+    
+        computeCommandEncoder.setComputePipelineState(computePipelineState)
+        computeCommandEncoder.setTexture(metalY, index: 0)
+        computeCommandEncoder.setTexture(metalUV, index: 1)
+        computeCommandEncoder.setTexture(outputTexture, index: 2)
+        
+        // Calculate the number of threads per threadgroup and the number of threadgroups
+        let threadGroupCount = MTLSize(width: 8, height: 8, depth: 1)
+        let threadGroups = MTLSize(width: (metalY.width + threadGroupCount.width - 1) / threadGroupCount.width,
+                                   height: (metalY.height + threadGroupCount.height - 1) / threadGroupCount.height,
+                                   depth: 1)
+        
+        // Encode the compute command and dispatch it
+        computeCommandEncoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadGroupCount)
+        computeCommandEncoder.endEncoding()
+        return self.outputTexture
+    }
+    
+    func convert(metalY: MTLTexture, metalUV: MTLTexture) -> MTLTexture? {
+        
+        // Prepare the command buffer and command encoder
+        guard let commandQueue = device.makeCommandQueue(),
+              let commandBuffer = commandQueue.makeCommandBuffer() else {
+            print("Failed to create command encoder")
+            return nil
+          }
+        
+        let outputTexture = addToBuffer(commandBuffer: commandBuffer, metalY:metalY, metalUV: metalUV)
+        // Commit the command buffer and wait for it to complete
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        return outputTexture
+    }
+}
+
+func GPUTextureToImage(texture: MTLTexture, device: MTLDevice) -> CGImage? {
+    let width = texture.width
+    let height = texture.height
+    let pixelByteCount = 4 * width * height
+
+    let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba8Unorm, width: width, height: height, mipmapped: false)
+    textureDescriptor.usage = [.shaderRead, .pixelFormatView]
+    textureDescriptor.storageMode = .shared
+
+    guard let sharedTexture = device.makeTexture(descriptor: textureDescriptor) else {
+        print("Failed to create shared texture")
+        return nil
+    }
+
+    guard let commandQueue = device.makeCommandQueue(),
+          let commandBuffer = commandQueue.makeCommandBuffer(),
+          let blitEncoder = commandBuffer.makeBlitCommandEncoder() else {
+        print("Failed to create command queue or command buffer")
+        return nil
+    }
+
+    blitEncoder.copy(from: texture,
+                     sourceSlice: 0,
+                     sourceLevel: 0,
+                     sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+                     sourceSize: MTLSize(width: texture.width, height: texture.height, depth: 1),
+                     to: sharedTexture,
+                     destinationSlice: 0,
+                     destinationLevel: 0,
+                     destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+    blitEncoder.endEncoding()
+    commandBuffer.commit()
+    commandBuffer.waitUntilCompleted()
+
+    // Prepare to read the texture data
+    let bytesPerRow = width * 4
+    var data = [UInt8](repeating: 0, count: Int(pixelByteCount))
+    sharedTexture.getBytes(&data, bytesPerRow: bytesPerRow, from: MTLRegionMake2D(0, 0, width, height), mipmapLevel: 0)
+
+    let providerRef = CGDataProvider(data: NSData(bytes: &data, length: data.count))
+    let bitmapInfo = CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue
+    let colorSpaceRef = CGColorSpaceCreateDeviceRGB()
+
+    guard let cgImage = CGImage(width: width,
+                                height: height,
+                                bitsPerComponent: 8,
+                                bitsPerPixel: 32,
+                                bytesPerRow: bytesPerRow,
+                                space: colorSpaceRef,
+                                bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+                                provider: providerRef!,
+                                decode: nil,
+                                shouldInterpolate: true,
+                                intent: CGColorRenderingIntent.defaultIntent) else {
+        return nil
+    }
+
+    return cgImage
+}
+
+
+func textureToImage(texture: MTLTexture) -> CGImage? {
+    let bytesPerPixel = 4
+    let bytesPerRow = bytesPerPixel * texture.width
+    let imageByteCount = bytesPerRow * texture.height
+    let imageBytes = UnsafeMutableRawPointer.allocate(byteCount: imageByteCount, alignment: bytesPerPixel)
+    defer {
+        imageBytes.deallocate()
+    }
+
+    // Create a region that covers the entire texture
+    let region = MTLRegionMake2D(0, 0, texture.width, texture.height)
+    // Read the texture data into the allocated bytes
+    texture.getBytes(imageBytes, bytesPerRow: bytesPerRow, from: region, mipmapLevel: 0)
+
+    // Create a CGImage from the bytes
+    let providerRef = CGDataProvider(data: NSData(bytesNoCopy: imageBytes, length: imageByteCount, freeWhenDone: true))
+    let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+    guard let cgImage = CGImage(width: texture.width,
+                                height: texture.height,
+                                bitsPerComponent: 8,
+                                bitsPerPixel: 32,
+                                bytesPerRow: bytesPerRow,
+                                space: CGColorSpaceCreateDeviceRGB(),
+                                bitmapInfo: bitmapInfo,
+                                provider: providerRef!,
+                                decode: nil,
+                                shouldInterpolate: false,
+                                intent: CGColorRenderingIntent.defaultIntent) else {
+        return nil
+    }
+    return cgImage
+}
+

--- a/ALVRClient/ImageUtils.swift
+++ b/ALVRClient/ImageUtils.swift
@@ -1,0 +1,8 @@
+//
+//  ImageUtils.swift
+//  ALVRClient
+//
+//  Created by 徐浩 on 2024/3/23.
+//
+
+import Foundation

--- a/ALVRClient/Info.plist
+++ b/ALVRClient/Info.plist
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>UIFileSharingEnabled</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
+	<key>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;
+&lt;plist version=&quot;1.0&quot;&gt;
+&lt;true/&gt;
+&lt;/plist&gt;
+&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;
+&lt;plist version=&quot;1.0&quot;&gt;
+&lt;true/&gt;
+&lt;/plist&gt;
+</key>
+	<string></string>
 	<key>NSHandsTrackingUsageDescription</key>
 	<string>ALVR would like to send hand positions and skeletons to SteamVR.</string>
 	<key>NSWorldSensingUsageDescription</key>

--- a/ALVRClient/MetalFXUpscaler.swift
+++ b/ALVRClient/MetalFXUpscaler.swift
@@ -1,0 +1,86 @@
+//
+//  MetalFXUpscaler.swift
+//
+//  Created by xuhao3e8 on 2024/3/16.
+//
+
+import Metal
+#if !targetEnvironment(simulator)
+import MetalFX
+#endif
+import CoreGraphics
+
+class MetalUpscaler {
+    private let device: MTLDevice
+    
+#if !targetEnvironment(simulator)
+    var mfxSpatialScaler: MTLFXSpatialScaler!
+#endif
+    var outputTexture: MTLTexture!
+    var scaling: Float32 = 1.0
+    var is_inited: Bool = false
+    
+    init?(device: MTLDevice, scaling: Float32 = 1.5) {
+        self.device = device
+        self.scaling = scaling
+    }
+    
+    func initUpscalerByTexture(inputTexture: MTLTexture) {
+        let inputWidth = inputTexture.width
+        let inputHeight = inputTexture.height
+        let pixelFormat = inputTexture.pixelFormat
+        self.setupSpatialScaler(inputWidth: inputWidth, inputHeight: inputHeight, scaling: scaling, pixelFormat: pixelFormat)
+        let textureDescriptor = MTLTextureDescriptor()
+        textureDescriptor.textureType = .type2D
+        textureDescriptor.pixelFormat = pixelFormat
+        textureDescriptor.width = Int(Float(inputWidth)*scaling)
+        textureDescriptor.height = Int(Float(inputHeight)*scaling)
+        textureDescriptor.storageMode = .private
+
+        // Optionally, set the usage of the texture. For rendering, you'll likely need shader read and render target capabilities
+        textureDescriptor.usage = [.shaderRead, .renderTarget]
+        self.outputTexture = device.makeTexture(descriptor: textureDescriptor)
+        self.is_inited = true
+        
+    }
+    
+    
+    func setupSpatialScaler(inputWidth:Int, inputHeight: Int, scaling: Float32, pixelFormat: MTLPixelFormat) {
+#if !targetEnvironment(simulator)
+        let desc = MTLFXSpatialScalerDescriptor()
+        desc.inputWidth = inputWidth
+        desc.inputHeight = inputHeight
+        desc.outputWidth = Int(Float(inputWidth)*scaling)
+        desc.outputHeight = Int(Float(inputHeight)*scaling)
+        desc.colorTextureFormat = pixelFormat
+        desc.outputTextureFormat = pixelFormat
+        desc.colorProcessingMode = .perceptual
+        
+        guard let spatialScaler = desc.makeSpatialScaler(device: device) else {
+            print("The spatial scaler effect is not usable!")
+            return
+        }
+        print("Init MetalFX,Spatial upscaler from [\(inputWidth)x\(inputHeight)] to [\(Int(Float(inputWidth)*scaling))x\(Int(Float(inputHeight)*scaling))] scaling \(scaling) format \(pixelFormat)")
+        mfxSpatialScaler = spatialScaler
+#endif
+    }
+    
+    func addUpscaleCommand(inputTexture: MTLTexture, commandBuffer: MTLCommandBuffer) -> MTLTexture! {
+        if (!is_inited)
+        {
+            initUpscalerByTexture(inputTexture: inputTexture)
+        }
+#if !targetEnvironment(simulator)
+        if let spatialScaler = mfxSpatialScaler {
+            spatialScaler.colorTexture = inputTexture
+            spatialScaler.outputTexture = self.outputTexture
+            spatialScaler.encode(commandBuffer: commandBuffer)
+            return self.outputTexture
+        }
+#else
+        return inputTexture
+#endif
+        return nil
+    }
+}
+

--- a/ALVRClient/MetalFXUpscaler.swift
+++ b/ALVRClient/MetalFXUpscaler.swift
@@ -1,7 +1,7 @@
 //
 //  MetalFXUpscaler.swift
 //
-//  Created by xuhao3e8 on 2024/3/16.
+//  Created by @xuhao1 on 2024/3/16.
 //
 
 import Metal

--- a/ALVRClient/Renderer.swift
+++ b/ALVRClient/Renderer.swift
@@ -953,7 +953,7 @@ class Renderer {
         renderEncoder.popDebugGroup()
         renderEncoder.endEncoding()
         
-        if (self.tick % 100 == 0 && self.upscaler != nil)
+        if (global_settings.enableDebugSaveScreenshot && self.tick % 100 == 0 && self.upscaler != nil)
         {
             let raw_image = GPUTextureToImage(texture: rgbTextureRaw!, device: device)!
             let upscaled_img = GPUTextureToImage(texture: rgbTextureUpscaled!, device: device)!

--- a/ALVRClient/Shaders.metal
+++ b/ALVRClient/Shaders.metal
@@ -206,15 +206,6 @@ struct VertexOut {
     float2 texCoord;
 };
 
-// Vertex shader
-vertex VertexOut basicVertexShader(constant VertexIn *vertexArray [[buffer(0)]],
-                                   uint vertexID [[vertex_id]]) {
-    VertexOut out;
-    out.position = vertexArray[vertexID].position;
-    out.texCoord = vertexArray[vertexID].texCoord;
-    return out;
-}
-
 kernel void yuvToRgbComputeKernel(
     texture2d<float, access::sample> yTexture [[ texture(0) ]],
     texture2d<float, access::sample> uvTexture [[ texture(1) ]],


### PR DESCRIPTION
This enables MetalFX for ALVR-visionos.
With a toggle to control if use MetalFX and upscaling factor selection, and also debug option to save raw image and upscaled image.
To use MetalFX, we need to convert YUV420 to RGB first.

**UI**

![IMG_0243](https://github.com/alvr-org/alvr-visionos/assets/5087930/98caa585-7328-40bf-bd0e-bea041891c8b)

![IMG_0242](https://github.com/alvr-org/alvr-visionos/assets/5087930/6adfe84b-ddf5-491e-be4c-44dd5ac90486)

**Comparsions:**
Top: raw
Bottom: Upscaled

<img width="1706" alt="截屏2024-03-23 18 04 18" src="https://github.com/alvr-org/alvr-visionos/assets/5087930/c86038f5-8efa-40e1-83bb-22d4406dbb77">

<img width="1686" alt="截屏2024-03-23 18 05 23" src="https://github.com/alvr-org/alvr-visionos/assets/5087930/5fac6e54-f2b8-49c5-90cc-55b2c876cfe0">

**Known issue:**
The R and B channel of saved image is opposite, but it's ok for debugging seeing these images.
Honestly, due to the bandwidth limitation of apple, metalfx does not change a lot currently.
