### PR TITLE
Disable Home palm gesture (toggle for .persistentSystemOverlays on Scenes)

### DIFF
--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -248,20 +248,24 @@ struct ALVRClientApp: App {
                 let renderer = DummyMetalRenderer(layerRenderer)
                 renderer.startRenderLoop()
             }
-        }.immersionStyle(selection: .constant(.full), in: .full)
-        
+        }
+        .persistentSystemOverlays(.hidden)
+        .immersionStyle(selection: .constant(.full), in: .full)
+
         ImmersiveSpace(id: "RealityKitClient") {
             RealityKitClientView()
         }
+        .persistentSystemOverlays(.hidden)
         .immersionStyle(selection: .constant(.mixed), in: .mixed)
         .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .visible : .hidden)
-        
+
         ImmersiveSpace(id: "MetalClient") {
             CompositorLayer(configuration: ContentStageConfiguration()) { layerRenderer in
                 let system = MetalClientSystem(layerRenderer)
                 system.startRenderLoop()
             }
         }
+        .persistentSystemOverlays(.hidden)
         .immersionStyle(selection: $clientImmersionStyle, in: .mixed, .full)
         .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .visible : .hidden)
     }

--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -249,15 +249,15 @@ struct ALVRClientApp: App {
                 renderer.startRenderLoop()
             }
         }
-        .persistentSystemOverlays(.hidden)
+        .disablePersistentSystemOverlaysForVisionOS2(shouldDisable: ALVRClientApp.gStore.settings.disablePersistentSystemOverlays ? .hidden : .automatic)
         .immersionStyle(selection: .constant(.full), in: .full)
 
         ImmersiveSpace(id: "RealityKitClient") {
             RealityKitClientView()
         }
-        .persistentSystemOverlays(.hidden)
+        .disablePersistentSystemOverlaysForVisionOS2(shouldDisable: ALVRClientApp.gStore.settings.disablePersistentSystemOverlays ? .hidden : .automatic)
         .immersionStyle(selection: .constant(.mixed), in: .mixed)
-        .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .visible : .hidden)
+        .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .automatic : .hidden)
 
         ImmersiveSpace(id: "MetalClient") {
             CompositorLayer(configuration: ContentStageConfiguration()) { layerRenderer in
@@ -265,8 +265,8 @@ struct ALVRClientApp: App {
                 system.startRenderLoop()
             }
         }
-        .persistentSystemOverlays(.hidden)
+        .disablePersistentSystemOverlaysForVisionOS2(shouldDisable: ALVRClientApp.gStore.settings.disablePersistentSystemOverlays ? .hidden : .automatic)
         .immersionStyle(selection: $clientImmersionStyle, in: .mixed, .full)
-        .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .visible : .hidden)
+        .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .automatic : .hidden)
     }
 }

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -86,7 +86,7 @@ struct Entry: View {
                     .toggleStyle(.switch)
                     
                     Toggle(isOn: $gStore.settings.disablePersistentSystemOverlays) {
-                        Text("Disable persistent system overlays")
+                        Text("Disable persistent system overlays (palm gesture)")
                     }
                     .toggleStyle(.switch)
                   

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -85,6 +85,11 @@ struct Entry: View {
                     }
                     .toggleStyle(.switch)
                     
+                    Toggle(isOn: $gStore.settings.disablePersistentSystemOverlays) {
+                        Text("Disable persistent system overlays")
+                    }
+                    .toggleStyle(.switch)
+                  
                     Toggle(isOn: $gStore.settings.keepSteamVRCenter) {
                         Text("Crown Button long-press ignored by SteamVR")
                     }

--- a/ALVRClient/Extensions/SwiftUI.swift
+++ b/ALVRClient/Extensions/SwiftUI.swift
@@ -3,9 +3,26 @@
 //
 
 import SwiftUI
+import CompositorServices
+
+//extension ImmersiveSpace<CompositorLayer, Never> {
+//  @ViewBuilder
+//  func disablePersistentSystemOverlaysForVisionOS2() -> some ImmersiveSpace {
+//#if XCODE_BETA_16
+//    if #available(visionOS 2.0, *) {
+//      self.persistentSystemOverlays(ALVRClientApp.gStore.settings.disablePersistentSystemOverlays ? .hidden : .visible)
+//    } else {
+//      self
+//    }
+//#else
+//    self
+//#endif
+//  }
+//}
 
 extension View {
-    @ViewBuilder
+
+  @ViewBuilder
     func newGameControllerSupportForVisionOS2() -> some View {
 #if XCODE_BETA_16
         if #available(visionOS 2.0, *) {  // Replace with the actual version where .handlesGameControllerEvents is available

--- a/ALVRClient/Extensions/SwiftUI.swift
+++ b/ALVRClient/Extensions/SwiftUI.swift
@@ -5,20 +5,19 @@
 import SwiftUI
 import CompositorServices
 
-//extension ImmersiveSpace<CompositorLayer, Never> {
-//  @ViewBuilder
-//  func disablePersistentSystemOverlaysForVisionOS2() -> some ImmersiveSpace {
-//#if XCODE_BETA_16
-//    if #available(visionOS 2.0, *) {
-//      self.persistentSystemOverlays(ALVRClientApp.gStore.settings.disablePersistentSystemOverlays ? .hidden : .visible)
-//    } else {
-//      self
-//    }
-//#else
-//    self
-//#endif
-//  }
-//}
+extension Scene {
+  func disablePersistentSystemOverlaysForVisionOS2(shouldDisable: Visibility) -> some Scene {
+#if XCODE_BETA_16
+    if #available(visionOS 2.0, *) {
+      return self.persistentSystemOverlays(shouldDisable)
+    } else {
+      return self
+    }
+#else
+    return self
+#endif
+  }
+}
 
 extension View {
 

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct GlobalSettings: Codable {
     var keepSteamVRCenter: Bool = true
     var showHandsOverlaid: Bool = false
-    var disablePersistentSystemOverlays: Bool = false
+    var disablePersistentSystemOverlays: Bool = true
     var streamFPS: String = "90"
     var experimental40ppd: Bool = false
     var chromaKeyEnabled: Bool = false

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct GlobalSettings: Codable {
     var keepSteamVRCenter: Bool = true
     var showHandsOverlaid: Bool = false
+    var disablePersistentSystemOverlays: Bool = false
     var streamFPS: String = "90"
     var experimental40ppd: Bool = false
     var chromaKeyEnabled: Bool = false
@@ -32,6 +33,7 @@ struct GlobalSettings: Codable {
         
         self.keepSteamVRCenter = try container.decodeIfPresent(Bool.self, forKey: .keepSteamVRCenter) ?? self.keepSteamVRCenter
         self.showHandsOverlaid = try container.decodeIfPresent(Bool.self, forKey: .showHandsOverlaid) ?? self.showHandsOverlaid
+        self.disablePersistentSystemOverlays = try container.decodeIfPresent(Bool.self, forKey: .disablePersistentSystemOverlays) ?? self.disablePersistentSystemOverlays
         self.streamFPS = try container.decodeIfPresent(String.self, forKey: .streamFPS) ?? self.streamFPS
         self.experimental40ppd = try container.decodeIfPresent(Bool.self, forKey: .experimental40ppd) ?? self.experimental40ppd
         self.chromaKeyEnabled = try container.decodeIfPresent(Bool.self, forKey: .chromaKeyEnabled) ?? self.chromaKeyEnabled

--- a/ALVRClient/RealityKitClientView.swift
+++ b/ALVRClient/RealityKitClientView.swift
@@ -188,7 +188,6 @@ struct RealityKitClientView: View {
 
         }
         .newGameControllerSupportForVisionOS2()
-        .persistentSystemOverlays(.hidden)
         .gesture(
             SpatialEventGesture(coordinateSpace: .local)
                 .targetedToAnyEntity()

--- a/ALVRClient/RealityKitClientView.swift
+++ b/ALVRClient/RealityKitClientView.swift
@@ -188,6 +188,7 @@ struct RealityKitClientView: View {
 
         }
         .newGameControllerSupportForVisionOS2()
+        .persistentSystemOverlays(.hidden)
         .gesture(
             SpatialEventGesture(coordinateSpace: .local)
                 .targetedToAnyEntity()


### PR DESCRIPTION
(request from Alex Coulombe aka @iBrews)

Add checkbox to set .persistentSystemOverlays=.hidden on Scenes, which disables the Home palm gesture.

I branched this from a slightly earlier commit on V20 as that branch was broken. It wasn't clear to me where you guys build the App Store release from for v20.11.1 as main is far behind.

WARN: If automerged, this will bump v20 branch to v20.11.1 for the ALVR submodule.

Let me know if you need me to rebase this from somewhere else prior to merge.

Also, the ALVRClientCore.xcframework rust code does not generate .dSYMs which means some manual work to push an App Store / TestFlight release. I had to manually generate them. How do you guys generate a release?