### PR TITLE
feat: add handle to enable progressive mode in `RealityKitClient`

### DIFF
--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -47,9 +47,11 @@ struct ALVRClientApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.openWindow) var openWindow
     @Environment(\.dismissWindow) var dismissWindow
-    @State private var clientImmersionStyle: ImmersionStyle = .mixed
-    
     static var gStore = GlobalSettingsStore()
+
+    @State private var clientImmersionStyle: ImmersionStyle = .mixed
+    @State private var realityKitImmersionStyle: ImmersionStyle = .mixed
+    
     @State private var chromaKeyColor = Color(.sRGB, red: 0.98, green: 0.9, blue: 0.2)
     
     static let shared = ALVRClientApp()
@@ -130,6 +132,8 @@ struct ALVRClientApp: App {
             .task {
                 if #unavailable(visionOS 2.0) {
                     clientImmersionStyle = .full
+                } else {
+                    realityKitImmersionStyle = ALVRClientApp.gStore.settings.enableProgressive ? .progressive : .mixed
                 }
                 loadSettings()
                 model.isShowingClient = false
@@ -207,7 +211,7 @@ struct ALVRClientApp: App {
             RealityKitClientView()
         }
         .disablePersistentSystemOverlaysForVisionOS2(shouldDisable: ALVRClientApp.gStore.settings.disablePersistentSystemOverlays ? .hidden : .automatic)
-        .immersionStyle(selection: .constant(.mixed), in: .mixed)
+        .immersionStyle(selection: $realityKitImmersionStyle, in: .mixed, .progressive)
         .upperLimbVisibility(ALVRClientApp.gStore.settings.showHandsOverlaid ? .visible : .hidden)
 
         ImmersiveSpace(id: "MetalClient") {

--- a/ALVRClient/Entry/Entry.swift
+++ b/ALVRClient/Entry/Entry.swift
@@ -238,6 +238,13 @@ struct Entry: View {
                             .font(.system(size: 10))
                     }
                     .toggleStyle(.switch)
+
+                    Toggle(isOn: $gStore.settings.enableProgressive) {
+                        Text("Enable progressive mode (use Digital Crown)")
+                        Text("*Currently requires RealityKit renderer")
+                            .font(.system(size: 10))
+                    }
+                    .toggleStyle(.switch)
                     
                     Toggle(isOn: $gStore.settings.dismissWindowOnEnter) {
                         Text("Dismiss this window on entry")

--- a/ALVRClient/GlobalSettings.swift
+++ b/ALVRClient/GlobalSettings.swift
@@ -28,6 +28,7 @@ struct GlobalSettings: Codable {
     var targetHandsAtRoundtripLatency = false
     var enablePersonaFaceTracking = false
     var showFaceTrackingDebug = false
+    var enableProgressive = false
     var lastUsedAppVersion = "never launched"
     
     init() {}
@@ -55,6 +56,7 @@ struct GlobalSettings: Codable {
         self.targetHandsAtRoundtripLatency = try container.decodeIfPresent(Bool.self, forKey: .targetHandsAtRoundtripLatency) ?? self.targetHandsAtRoundtripLatency
         self.enablePersonaFaceTracking = try container.decodeIfPresent(Bool.self, forKey: .enablePersonaFaceTracking) ?? self.enablePersonaFaceTracking
         self.showFaceTrackingDebug = try container.decodeIfPresent(Bool.self, forKey: .showFaceTrackingDebug) ?? self.showFaceTrackingDebug
+        self.enableProgressive = try container.decodeIfPresent(Bool.self, forKey: .enableProgressive) ?? self.enableProgressive
         self.lastUsedAppVersion = try container.decodeIfPresent(String.self, forKey: .lastUsedAppVersion) ?? self.lastUsedAppVersion
     }
 }


### PR DESCRIPTION
This pull request adds a new toggle to allow the crown dial to adjust the immersion level of the VR space. This *only* works in RealityKit, trying to enable this for the `MetalClient` fails. I don't know enough about the `CompositorLayer` to understand why it requires  `.full`. This feature is off by default.

This might conflict with the chroma key rendering, testing... Edit: chroma seems to be working identically as before my changes, though I've never really used this feature. Unsure of all of its use cases?

<img width="1420" height="1385" alt="image" src="https://github.com/user-attachments/assets/6326fa05-7cf5-4f6c-b9e8-ce84c9e8dddd" />