### PR TITLE
Fix: Load Settings before accessing 

### DIFF
--- a/ALVRClient/ALVRClientApp.swift
+++ b/ALVRClient/ALVRClientApp.swift
@@ -130,12 +130,12 @@ struct ALVRClientApp: App {
                 }
             }
             .task {
+                loadSettings()
                 if #unavailable(visionOS 2.0) {
                     clientImmersionStyle = .full
                 } else {
                     realityKitImmersionStyle = ALVRClientApp.gStore.settings.enableProgressive ? .progressive : .mixed
                 }
-                loadSettings()
                 model.isShowingClient = false
                 EventHandler.shared.initializeAlvr()
                 await WorldTracker.shared.initializeAr()


### PR DESCRIPTION
This is a follow-up to #159. This PR added support for progressive immersion, but it seems that it would never work because the settings were accessed before they were loaded.

This appears to fix the issue. You can verify by enabling the feature and seeing that it now allows for progressive immersion
<img width="2890" height="1642" alt="CleanShot 2026-02-03 at 20 55 47@2x" src="https://github.com/user-attachments/assets/acd0ae3a-d465-45e3-9d4e-063d382fdec3" />
